### PR TITLE
Implements AI suggestion limits and exemptions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 NUXT_ATP_SERVICE= 'https://bsky.social' // there's no need to change this for now
-NUXT_OPENAI_API_KEY = your_openai_api_key // your OpenAI API key
+// NUXT_OPENAI_API_KEY = your_openai_api_key // your OpenAI API key
+// NUXT_EXEMPT_DIDS = did:plc:wipjtybmy4zg7n6i62lip5p7 // your exempt dids, if any

--- a/README.md
+++ b/README.md
@@ -7,11 +7,13 @@ Hey there! We're launching the very first prototype version of Bluelist. This is
 - **View Your Lists**: See all the lists you've already created on Bluesky
 - **Browse Your Follows**: Simple interface to view who you're following
 - **Add to Lists**: Easily add users to your existing lists with a few clicks
-- **✨ AI Suggestions**: Get AI-powered recommendations for organizing your follows into lists (free during this early stage, but may change later!)
+- **✨ AI Suggestions**: Get AI-powered recommendations for organizing your follows into lists
 
 ## Important Note
 
-This is very much an **early prototype**! Expect bugs, limited features, and rough edges.
+- This is very much an **early prototype**! Expect bugs, limited features, and rough edges.
+- AI suggestions limited to 5 requests per day, with exception handling for certain users
+- AI suggestions is free during this early stage, but may change later!
 
 ## Local Testing Requirements
 
@@ -19,8 +21,17 @@ If you want to run this locally, you'll need:
 
 - An OpenAI developer account
 - Your own OpenAI API key (set in the environment variables)
+- Optional: Set exempt DIDs in the environment variables to bypass daily limits
 
 This is only for local development and testing. The deployed version handles API access for you.
+
+### Environment Variables
+
+```
+NUXT_OPENAI_API_KEY=your_openai_key_here
+NUXT_ATP_SERVICE=your_atp_service_url
+NUXT_EXEMPT_DIDS=did1,did2,did3  # Optional: Comma-separated list of DIDs exempt from daily limits
+```
 
 ### Setup
 
@@ -64,6 +75,14 @@ We're just getting started! Here's what we're working on:
 ## Technical Details
 
 Built with Nuxt 3, ATP Protocol integration, and a focus on making list management easier for Bluesky users.
+
+## Feature Details
+
+### AI Suggestions
+
+- Limited to 5 requests per user per day (to manage API costs)
+- Certain users can be exempted from this limit through the exempt users API
+- Remaining request count is tracked and displayed to users
 
 ## Questions or Suggestions?
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -8,6 +8,7 @@ export default defineNuxtConfig({
   },
   runtimeConfig: {
     openaiApiKey: process.env.NUXT_OPENAI_API_KEY,
+    exemptDids: process.env.NUXT_EXEMPT_DIDS,
     public: {
       atpService: process.env.NUXT_ATP_SERVICE,
     },

--- a/server/api/exemptUsers.ts
+++ b/server/api/exemptUsers.ts
@@ -1,0 +1,22 @@
+import { defineEventHandler, readBody } from 'h3';
+import { useRuntimeConfig } from '#imports';
+
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig();
+  const EXEMPT_DIDS = config.exemptDids ? config.exemptDids.split(',') : [];
+
+  const { did } = await readBody(event);
+
+  if (!did) {
+    return {
+      isExempt: false,
+      error: 'No DID provided',
+    };
+  }
+
+  const isExempt = EXEMPT_DIDS.includes(did);
+
+  return {
+    isExempt,
+  };
+});

--- a/src/components/ActionButton.vue
+++ b/src/components/ActionButton.vue
@@ -1,8 +1,10 @@
 <template>
   <button
     class="action-button"
-    :class="uiStore.isProcessingSuggestions ? 'action-button--processing' : ''"
-    :disabled="uiStore.isProcessingSuggestions"
+    :class="
+      suggestionStore.isProcessingSuggestions ? 'action-button--processing' : ''
+    "
+    :disabled="suggestionStore.isProcessingSuggestions"
     @click="onClick"
   >
     <span class="action-button__icon">{{ icon }}</span>
@@ -11,13 +13,13 @@
 </template>
 
 <script setup lang="ts">
-import { useUiStore } from '~/src/stores/ui';
+import { useSuggestionsStore } from '~/src/stores/suggestions';
 
 defineOptions({
   name: 'ActionButton',
 });
 
-const uiStore = useUiStore();
+const suggestionStore = useSuggestionsStore();
 
 defineProps<{
   icon: string;

--- a/src/components/ButtonsPanel.vue
+++ b/src/components/ButtonsPanel.vue
@@ -1,7 +1,9 @@
 <template>
   <div
     class="buttons-panel"
-    :class="{ 'buttons-panel--disabled': uiStore.isProcessingSuggestions }"
+    :class="{
+      'buttons-panel--disabled': suggestionsStore.isProcessingSuggestions,
+    }"
   >
     <NuxtLink v-slot="{ navigate }" to="/lists" custom>
       <ActionButton icon="[#]" label="Lists" @click="() => navigate()" />
@@ -21,6 +23,7 @@ import { getTimeline, getLists, getFollows } from '~/src/lib/bsky';
 import { useFollowsStore } from '~/src/stores/follows';
 import { useListsStore } from '~/src/stores/lists';
 import { useUiStore } from '~/src/stores/ui';
+import { useSuggestionsStore } from '~/src/stores/suggestions';
 import ActionButton from '~/src/components/ActionButton.vue';
 import type { DataObject } from '~/src/types/index';
 
@@ -31,6 +34,7 @@ defineOptions({
 const followsStore = useFollowsStore();
 const listsStore = useListsStore();
 const uiStore = useUiStore();
+const suggestionsStore = useSuggestionsStore();
 
 const setLoading = () => {
   uiStore.setDisplayData({

--- a/src/components/DataCard.vue
+++ b/src/components/DataCard.vue
@@ -5,7 +5,7 @@
       'data-card--timeline': item.type === 'timeline',
       'data-card--list': item.type === 'lists',
       'data-card--follow': item.type === 'follows',
-      'data-card--loading': uiStore.isProcessingSuggestions,
+      'data-card--loading': suggestionsStore.isProcessingSuggestions,
     }"
   >
     <div v-if="item.type === 'timeline' && timelineItem">
@@ -65,7 +65,7 @@
 </template>
 
 <script setup lang="ts">
-import { useUiStore } from '~/src/stores/ui';
+import { useSuggestionsStore } from '~/src/stores/suggestions';
 import '~/src/assets/styles/data-card.css';
 import ListChips from '~/src/components/ListChips.vue';
 import type {
@@ -79,7 +79,7 @@ defineOptions({
   name: 'DataCard',
 });
 
-const uiStore = useUiStore();
+const suggestionsStore = useSuggestionsStore();
 
 const props = defineProps<{
   item: DataObject;

--- a/src/components/DataDisplay.vue
+++ b/src/components/DataDisplay.vue
@@ -64,7 +64,7 @@
       >
         <button
           class="data-display__suggestions-button"
-          :title="`Get suggestions for your follows (${remainingSuggestions}/5 remaining today)`"
+          :title="suggestionsButtonTitle"
           :class="{
             'data-display__suggestions-button--processing':
               suggestionsStore.isProcessingSuggestions,
@@ -79,11 +79,7 @@
         >
           <span class="data-display__suggestions-icon">[*]</span>
           <span class="data-display__suggestions-text">{{
-            suggestionsStore.isProcessingSuggestions
-              ? 'Processing'
-              : hasReachedSuggestionLimit
-              ? 'Limit Reached'
-              : 'Suggest Lists'
+            suggestionsButtonLabel
           }}</span>
         </button>
         <button
@@ -228,6 +224,7 @@ import type {
   ListItem,
   FollowItem,
   SuggestionItem,
+  DetailedResult,
 } from '~/src/types/index';
 import { addUserToList } from '~/src/lib/bsky';
 import { curateUserLists } from '~/src/lib/openai';
@@ -282,15 +279,24 @@ const errorMessage = computed(() => {
   return 'An unknown error occurred';
 });
 
-interface DetailedResult {
-  profileName: string;
-  profileDid: string;
-  listName: string;
-  listUri: string;
-  success: boolean;
-  message: string;
-  isDuplicate: boolean;
-}
+const suggestionsButtonTitle = computed(() => {
+  const buttonTitle =
+    remainingSuggestions.value === 999
+      ? 'You have unlimited suggestions available'
+      : `${remainingSuggestions.value}/5 suggestions request remaining today`;
+  return buttonTitle;
+});
+
+const suggestionsButtonLabel = computed(() => {
+  if (suggestionsStore.isProcessingSuggestions) {
+    return 'Processing';
+  } else if (hasReachedSuggestionLimit.value) {
+    return 'Limit Reached';
+  } else {
+    return 'Suggest Lists';
+  }
+});
+
 const dataCardRefs = ref<
   ComponentPublicInstance<InstanceType<typeof DataCard>>[]
 >([]);

--- a/src/components/Pagination.vue
+++ b/src/components/Pagination.vue
@@ -10,7 +10,9 @@
       <button
         class="pagination__button"
         :disabled="
-          currentPage === 1 || isLoading || uiStore.isProcessingSuggestions
+          currentPage === 1 ||
+          isLoading ||
+          suggestionsStore.isProcessingSuggestions
         "
         title="First page"
         @click="handlePageChange(1)"
@@ -20,7 +22,9 @@
       <button
         class="pagination__button"
         :disabled="
-          currentPage === 1 || isLoading || uiStore.isProcessingSuggestions
+          currentPage === 1 ||
+          isLoading ||
+          suggestionsStore.isProcessingSuggestions
         "
         title="Previous page"
         @click="handlePageChange(currentPage - 1)"
@@ -30,7 +34,7 @@
       <button
         class="pagination__button"
         :disabled="
-          !hasMorePages || isLoading || uiStore.isProcessingSuggestions
+          !hasMorePages || isLoading || suggestionsStore.isProcessingSuggestions
         "
         title="Next page"
         @click="handlePageChange(currentPage + 1)"
@@ -39,7 +43,9 @@
       </button>
       <button
         class="pagination__button"
-        :disabled="isLastPage || isLoading || uiStore.isProcessingSuggestions"
+        :disabled="
+          isLastPage || isLoading || suggestionsStore.isProcessingSuggestions
+        "
         title="Skip to last loaded page"
         @click="handlePageChange(lastPage)"
       >
@@ -54,7 +60,7 @@ import { computed } from 'vue';
 import '~/src/assets/styles/pagination.css';
 import { useFollowsStore } from '~/src/stores/follows';
 import { useListsStore } from '~/src/stores/lists';
-import { useUiStore } from '~/src/stores/ui';
+import { useSuggestionsStore } from '~/src/stores/suggestions';
 
 defineOptions({
   name: 'PaginationControls',
@@ -62,7 +68,7 @@ defineOptions({
 
 const followsStore = useFollowsStore();
 const listsStore = useListsStore();
-const uiStore = useUiStore();
+const suggestionsStore = useSuggestionsStore();
 
 const props = defineProps<{
   currentPage: number;

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia';
 import { AtpService } from '~/src/lib/AtpService';
+import { useSuggestionsStore } from './suggestions';
 
 export const useAuthStore = defineStore('auth', {
   state: () => ({
@@ -25,6 +26,8 @@ export const useAuthStore = defineStore('auth', {
 
     login() {
       this.isLoggedIn = true;
+      const suggestionsStore = useSuggestionsStore();
+      suggestionsStore.loadRequestCounts();
     },
 
     logout() {
@@ -32,7 +35,6 @@ export const useAuthStore = defineStore('auth', {
       this.loginError = '';
       this.did = '';
       this.isLoggedIn = false;
-      // Use the centralized API service to reset the agent
       AtpService.resetAgent();
     },
 
@@ -41,7 +43,6 @@ export const useAuthStore = defineStore('auth', {
     },
 
     getAgent() {
-      // Use the centralized API service instead of maintaining agent instance here
       return AtpService.getAgent();
     },
   },

--- a/src/stores/suggestions.ts
+++ b/src/stores/suggestions.ts
@@ -1,0 +1,121 @@
+import { defineStore } from 'pinia';
+import { useAuthStore } from './auth';
+import type { RequestCounts } from '~/src/types/index';
+
+const MAX_DAILY_SUGGESTIONS = 5;
+
+const isLimitOverridden = async () => {
+  const authStore = useAuthStore();
+  if (authStore.did) {
+    try {
+      const response = await fetch('/api/exemptUsers', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ did: authStore.did }),
+      });
+
+      const data = await response.json();
+      if (data.isExempt) {
+        return true;
+      }
+    } catch (error) {
+      console.error('Failed to check exemption status:', error);
+    }
+  }
+};
+
+export const useSuggestionsStore = defineStore('suggestions', {
+  state: () => ({
+    isProcessingSuggestions: false,
+    requestCounts: {} as RequestCounts,
+    suggestionsJSON: '',
+  }),
+
+  actions: {
+    setIsProcessing(isProcessing: boolean) {
+      this.isProcessingSuggestions = isProcessing;
+    },
+
+    setSuggestionsJSON(json: string) {
+      this.suggestionsJSON = json;
+    },
+
+    loadRequestCounts() {
+      const authStore = useAuthStore();
+      if (!authStore.did) return;
+
+      try {
+        const storedData = localStorage.getItem(
+          `suggestionRequests_${authStore.did}`
+        );
+        if (storedData) {
+          this.requestCounts = JSON.parse(storedData);
+        }
+      } catch (error) {
+        console.error('Failed to load suggestion request data:', error);
+        this.requestCounts = {};
+      }
+    },
+
+    saveRequestCounts() {
+      const authStore = useAuthStore();
+      if (!authStore.did) return;
+
+      try {
+        localStorage.setItem(
+          `suggestionRequests_${authStore.did}`,
+          JSON.stringify(this.requestCounts)
+        );
+      } catch (error) {
+        console.error('Failed to save suggestion request data:', error);
+      }
+    },
+
+    async trackRequest() {
+      const authStore = useAuthStore();
+      if (!authStore.did) return;
+
+      const overridden = await isLimitOverridden();
+      if (overridden) return;
+
+      const today = new Date().toISOString().split('T')[0];
+
+      if (!this.requestCounts[today]) {
+        this.requestCounts[today] = 0;
+      }
+
+      this.requestCounts[today]++;
+      this.saveRequestCounts();
+    },
+
+    async hasReachedLimit(): Promise<boolean> {
+      const overridden = await isLimitOverridden();
+      if (overridden) return false;
+
+      const authStore = useAuthStore();
+      if (!authStore.did) return false;
+
+      const today = new Date().toISOString().split('T')[0];
+      return (this.requestCounts[today] || 0) >= MAX_DAILY_SUGGESTIONS;
+    },
+
+    async getRemainingRequests(): Promise<number> {
+      const overridden = await isLimitOverridden();
+      if (overridden) return 999;
+
+      const authStore = useAuthStore();
+      if (!authStore.did) return MAX_DAILY_SUGGESTIONS;
+
+      const today = new Date().toISOString().split('T')[0];
+      const used = this.requestCounts[today] || 0;
+      return Math.max(0, MAX_DAILY_SUGGESTIONS - used);
+    },
+
+    resetCounts() {
+      this.requestCounts = {};
+      this.saveRequestCounts();
+    },
+  },
+});

--- a/src/stores/suggestions.ts
+++ b/src/stores/suggestions.ts
@@ -22,6 +22,7 @@ const isLimitOverridden = async () => {
       }
     } catch (error) {
       console.error('Failed to check exemption status:', error);
+      throw new Error('Failed to check exemption status');
     }
   }
 };

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -5,7 +5,6 @@ export const useUiStore = defineStore('ui', {
   state: () => ({
     displayData: null as DataObject | null,
     timelineJSON: '',
-    isProcessingSuggestions: false,
   }),
 
   actions: {
@@ -15,10 +14,6 @@ export const useUiStore = defineStore('ui', {
 
     setTimelineJSON(json: string) {
       this.timelineJSON = json;
-    },
-
-    setIsProcessingSuggestions(isProcessing: boolean) {
-      this.isProcessingSuggestions = isProcessing;
     },
   },
 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -196,6 +196,16 @@ export interface BskyAgent {
   };
 }
 
+export interface DetailedResult {
+  profileName: string;
+  profileDid: string;
+  listName: string;
+  listUri: string;
+  success: boolean;
+  message: string;
+  isDuplicate: boolean;
+}
+
 export interface RequestCounts {
   [date: string]: number;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -195,3 +195,7 @@ export interface BskyAgent {
     setHeader: (name: string, value: string) => void;
   };
 }
+
+export interface RequestCounts {
+  [date: string]: number;
+}


### PR DESCRIPTION
Introduces rate limiting for AI suggestion requests and allows for exempting certain users from these limits.

- Prevents excessive API usage by limiting users to 5 AI suggestions per day.
- Adds the ability to exempt specific users (identified by their DIDs) from the daily limit, configurable via environment variables.
- Displays the remaining suggestion requests to the user.