### PR TITLE
feat: opt-in dev environment profiles via env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,17 @@
-NUXT_ATP_SERVICE= 'https://bsky.social' // there's no need to change this for now
-// NUXT_OPENAI_API_KEY = your_openai_api_key // your OpenAI API key
-// NUXT_EXEMPT_DIDS = 'did:plc:example1,did:plc:example2' // your exempt dids, if any, separated by commas
+NUXT_ATP_SERVICE=https://bsky.social # there's no need to change this for now
+# NUXT_OPENAI_API_KEY=your_openai_api_key
+# NUXT_EXEMPT_DIDS=did:plc:example1,did:plc:example2 # comma-separated DIDs exempt from daily AI limits
+
+# --- macOS HTTPS profile (opt-in) ---
+# Uncomment and set these to run the dev server over HTTPS on a custom local domain.
+# Requires mkcert certs in ./certs/ and a /etc/hosts entry for the domain.
+# Port 4430 avoids the need for sudo or pf port-forwarding.
+# NUXT_DEV_HTTPS=true
+# NUXT_DEV_HOST=bluelist-local.blue
+# NUXT_DEV_PORT=4430
+# NUXT_DEV_SSL_KEY=./certs/bluelist-local.blue-key.pem
+# NUXT_DEV_SSL_CERT=./certs/bluelist-local.blue.pem
+
+# --- Bayer corporate proxy profile (opt-in) ---
+# Uncomment if your machine routes outbound HTTPS through a corporate proxy with a custom CA.
+# NODE_EXTRA_CA_CERTS=./certs/bayer-proxy-ca.pem

--- a/README.md
+++ b/README.md
@@ -29,11 +29,54 @@ This is only for local development and testing. The deployed version handles API
 
 ### Environment Variables
 
+Copy `.env.example` to `.env.local` and fill in your values:
+
+```bash
+cp .env.example .env.local
+```
+
+Required:
+
+```
+NUXT_ATP_SERVICE=https://bsky.social
+```
+
+Optional:
+
 ```
 NUXT_OPENAI_API_KEY=your_openai_key_here
-NUXT_ATP_SERVICE=your_atp_service_url
 NUXT_EXEMPT_DIDS=did1,did2,did3  # Optional: Comma-separated list of DIDs exempt from daily limits
 ```
+
+### Environment Profiles
+
+The dev server defaults to `http://localhost:3000` with no extra configuration needed. Platform-specific setups are opt-in via `.env.local` only — no code changes required.
+
+**WSL / any clean machine** — default, nothing to add.
+
+**macOS with HTTPS and a custom local domain:**
+
+```
+NUXT_DEV_HTTPS=true
+NUXT_DEV_HOST=bluelist-local.blue
+NUXT_DEV_PORT=4430
+NUXT_DEV_SSL_KEY=./certs/bluelist-local.blue-key.pem
+NUXT_DEV_SSL_CERT=./certs/bluelist-local.blue.pem
+```
+
+> Prerequisites: add `127.0.0.1 bluelist-local.blue` to `/etc/hosts`, install
+> [mkcert](https://github.com/FiloSottile/mkcert), run `mkcert -install` and
+> `mkcert bluelist-local.blue` inside `./certs/`.
+
+**Corporate proxy with a custom CA:**
+
+```
+NODE_EXTRA_CA_CERTS=./certs/bayer-proxy-ca.pem
+```
+
+> Place your corporate CA certificate at the path above. The launcher
+> (`scripts/run.mjs`) automatically detects and injects it before the Node TLS
+> stack initialises. If the file is absent the variable is silently ignored.
 
 ### Setup
 
@@ -45,11 +88,13 @@ yarn install
 
 ### Development Server
 
-Start the development server on `http://localhost:3000`:
+Start the development server:
 
 ```bash
 yarn dev
 ```
+
+Serves `http://localhost:3000` by default, or HTTPS on the configured host/port when `NUXT_DEV_HTTPS=true`.
 
 ### Production
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ NODE_EXTRA_CA_CERTS=./certs/bayer-proxy-ca.pem
 
 > Place your corporate CA certificate at the path above. The launcher
 > (`scripts/run.mjs`) automatically detects and injects it before the Node TLS
-> stack initialises. If the file is absent the variable is silently ignored.
+> stack initialises. If the variable is unset it is silently skipped; if it is
+> set but the file is missing, a warning is logged and the variable is ignored.
 
 ### Setup
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,5 +1,19 @@
-import { resolve } from 'path';
-import fs from 'fs';
+import { resolve } from 'node:path';
+import fs from 'node:fs';
+
+const useHttps = process.env.NUXT_DEV_HTTPS === 'true';
+
+function readCert(envVar: string, fallback: string): string | undefined {
+  const filePath = resolve(__dirname, process.env[envVar] ?? fallback);
+  try {
+    return fs.existsSync(filePath)
+      ? fs.readFileSync(filePath, 'utf-8')
+      : undefined;
+  } catch (error) {
+    console.warn(`Failed to read cert file ${filePath}: ${error}`);
+    return undefined;
+  }
+}
 
 export default defineNuxtConfig({
   compatibilityDate: '2025-03-21',
@@ -15,35 +29,17 @@ export default defineNuxtConfig({
       atpService: process.env.NUXT_ATP_SERVICE,
     },
   },
-  devServer: {
-    https: {
-      key: (() => {
-        const keyPath = resolve(
-          __dirname,
+  ...(useHttps && {
+    devServer: {
+      https: {
+        key: readCert(
+          'NUXT_DEV_SSL_KEY',
           './certs/bluelist-local.blue-key.pem'
-        );
-        try {
-          return fs.existsSync(keyPath)
-            ? fs.readFileSync(keyPath, 'utf-8')
-            : undefined;
-        } catch (error) {
-          console.warn(`Failed to read SSL key: ${error}`);
-          return undefined;
-        }
-      })(),
-      cert: (() => {
-        const certPath = resolve(__dirname, './certs/bluelist-local.blue.pem');
-        try {
-          return fs.existsSync(certPath)
-            ? fs.readFileSync(certPath, 'utf-8')
-            : undefined;
-        } catch (error) {
-          console.warn(`Failed to read SSL certificate: ${error}`);
-          return undefined;
-        }
-      })(),
+        ),
+        cert: readCert('NUXT_DEV_SSL_CERT', './certs/bluelist-local.blue.pem'),
+      },
+      host: process.env.NUXT_DEV_HOST ?? 'bluelist-local.blue',
+      port: Number(process.env.NUXT_DEV_PORT ?? 4430),
     },
-    host: 'bluelist-local.blue',
-    port: 443,
-  },
+  }),
 });

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -39,7 +39,7 @@ export default defineNuxtConfig({
         cert: readCert('NUXT_DEV_SSL_CERT', './certs/bluelist-local.blue.pem'),
       },
       host: process.env.NUXT_DEV_HOST ?? 'bluelist-local.blue',
-      port: Number(process.env.NUXT_DEV_PORT ?? 4430),
+      port: parseInt(process.env.NUXT_DEV_PORT ?? '', 10) || 4430,
     },
   }),
 });

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "nuxt build --dotenv .env.local",
-    "dev": "nuxt dev --dotenv .env.local",
+    "build": "node scripts/run.mjs build",
+    "dev": "node scripts/run.mjs dev",
     "generate": "nuxt generate --dotenv .env.local",
-    "preview": "nuxt preview --dotenv .env.local",
+    "preview": "node scripts/run.mjs preview",
     "postinstall": "nuxt prepare",
     "lint": "eslint .",
     "format": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "node scripts/run.mjs build",
     "dev": "node scripts/run.mjs dev",
-    "generate": "nuxt generate --dotenv .env.local",
+    "generate": "node scripts/run.mjs generate",
     "preview": "node scripts/run.mjs preview",
     "postinstall": "nuxt prepare",
     "lint": "eslint .",

--- a/scripts/run.mjs
+++ b/scripts/run.mjs
@@ -24,12 +24,12 @@ const envFile = resolve(root, '.env.local');
 const cmd = process.argv[2];
 
 if (!cmd) {
-  console.error('Usage: node scripts/run.mjs <dev|build|preview>');
+  console.error('Usage: node scripts/run.mjs <dev|build|preview|generate>');
   process.exit(1);
 }
 
 // Parse .env.local to extract variable values without using a runtime import.
-// Only picks up lines of the form KEY=VALUE (ignores comments and blank lines).
+// Handles quoted values, inline comments, and blank lines correctly.
 function parseEnvFile(filePath) {
   const vars = {};
   if (!existsSync(filePath)) return vars;
@@ -40,7 +40,19 @@ function parseEnvFile(filePath) {
     const eqIdx = trimmed.indexOf('=');
     if (eqIdx === -1) continue;
     const key = trimmed.slice(0, eqIdx).trim();
-    const value = trimmed.slice(eqIdx + 1).trim().replace(/^['"]|['"]$/g, '');
+    let value = trimmed.slice(eqIdx + 1).trim();
+    const maybeQuote = value[0];
+    if (maybeQuote === '"' || maybeQuote === "'" || maybeQuote === '`') {
+      const endIdx = value.indexOf(maybeQuote, 1);
+      if (endIdx !== -1) {
+        value = value.slice(1, endIdx);
+      }
+    } else {
+      const hashIdx = value.indexOf('#');
+      if (hashIdx !== -1) {
+        value = value.slice(0, hashIdx).trim();
+      }
+    }
     vars[key] = value;
   }
   return vars;
@@ -78,5 +90,10 @@ const result = spawnSync(nuxtBin, args, {
   env: childEnv,
   stdio: 'inherit',
 });
+
+if (result.error) {
+  console.error('[run.mjs] Failed to start Nuxt:', result.error);
+  process.exit(1);
+}
 
 process.exit(result.status ?? 1);

--- a/scripts/run.mjs
+++ b/scripts/run.mjs
@@ -11,6 +11,7 @@
  *   node scripts/run.mjs dev
  *   node scripts/run.mjs build
  *   node scripts/run.mjs preview
+ *   node scripts/run.mjs generate
  */
 
 import { spawnSync } from 'node:child_process';
@@ -78,7 +79,8 @@ const args = [cmd, '--dotenv', '.env.local'];
 
 // Resolve the nuxt binary from the local node_modules to avoid relying on
 // the shell PATH and to prevent any PATH-based injection.
-const nuxtBin = resolve(root, 'node_modules', '.bin', 'nuxt');
+// On Windows, yarn/npm create nuxt.cmd rather than a bare nuxt symlink.
+const nuxtBin = resolve(root, 'node_modules', '.bin', process.platform === 'win32' ? 'nuxt.cmd' : 'nuxt');
 
 if (!existsSync(nuxtBin)) {
   console.error(`[run.mjs] nuxt binary not found at ${nuxtBin}. Run 'yarn install' first.`);

--- a/scripts/run.mjs
+++ b/scripts/run.mjs
@@ -1,0 +1,82 @@
+/**
+ * Cross-platform dev launcher.
+ *
+ * Reads .env.local and — only when NODE_EXTRA_CA_CERTS is defined there and
+ * the referenced file exists — injects it into the child process environment
+ * before spawning nuxt. This is necessary because NODE_EXTRA_CA_CERTS must
+ * be set before Node's TLS stack initialises; dotenv loaded inside nuxt is
+ * too late.
+ *
+ * Usage (via package.json scripts):
+ *   node scripts/run.mjs dev
+ *   node scripts/run.mjs build
+ *   node scripts/run.mjs preview
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+const envFile = resolve(root, '.env.local');
+const cmd = process.argv[2];
+
+if (!cmd) {
+  console.error('Usage: node scripts/run.mjs <dev|build|preview>');
+  process.exit(1);
+}
+
+// Parse .env.local to extract variable values without using a runtime import.
+// Only picks up lines of the form KEY=VALUE (ignores comments and blank lines).
+function parseEnvFile(filePath) {
+  const vars = {};
+  if (!existsSync(filePath)) return vars;
+  const lines = readFileSync(filePath, 'utf-8').split('\n');
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1) continue;
+    const key = trimmed.slice(0, eqIdx).trim();
+    const value = trimmed.slice(eqIdx + 1).trim().replace(/^['"]|['"]$/g, '');
+    vars[key] = value;
+  }
+  return vars;
+}
+
+const envVars = parseEnvFile(envFile);
+const childEnv = { ...process.env };
+
+// Inject NODE_EXTRA_CA_CERTS only when the file actually exists on this machine.
+const caPath = envVars['NODE_EXTRA_CA_CERTS'];
+if (caPath) {
+  const resolvedCaPath = resolve(root, caPath);
+  if (existsSync(resolvedCaPath)) {
+    childEnv['NODE_EXTRA_CA_CERTS'] = resolvedCaPath;
+  } else {
+    console.warn(
+      `[run.mjs] NODE_EXTRA_CA_CERTS is set but file not found: ${resolvedCaPath} — skipping.`
+    );
+  }
+}
+
+const args = [cmd, '--dotenv', '.env.local'];
+
+// Resolve the nuxt binary from the local node_modules to avoid relying on
+// the shell PATH and to prevent any PATH-based injection.
+const nuxtBin = resolve(root, 'node_modules', '.bin', 'nuxt');
+
+if (!existsSync(nuxtBin)) {
+  console.error(`[run.mjs] nuxt binary not found at ${nuxtBin}. Run 'yarn install' first.`);
+  process.exit(1);
+}
+
+const result = spawnSync(nuxtBin, args, {
+  cwd: root,
+  env: childEnv,
+  stdio: 'inherit',
+});
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary

Replaces the hardcoded macOS-only HTTPS dev server config with an opt-in system driven entirely by `.env.local`. Adds a cross-platform launcher (`scripts/run.mjs`) that injects `NODE_EXTRA_CA_CERTS` before Node's TLS stack initialises — which dotenv-inside-nuxt is too late to do.

**No code changes are required to switch profiles** — everything is controlled via `.env.local`.

## Changes

- **`scripts/run.mjs`** — new cross-platform launcher; reads `.env.local`, injects corporate CA cert if present, then spawns nuxt
- **`package.json`** — route `dev`, `build`, `preview` through the launcher
- **`nuxt.config.ts`** — replace always-on `devServer` block with opt-in `...(useHttps && { devServer: … })`; cert paths and host/port are now configurable via env vars
- **`.env.example`** — add macOS HTTPS profile and Bayer corporate proxy profile (both opt-in, commented out)
- **`README.md`** — add "Environment Profiles" section documenting WSL / macOS HTTPS / corporate proxy setups

## How to opt in

```env
# macOS HTTPS
NUXT_DEV_HTTPS=true
NUXT_DEV_HOST=bluelist-local.blue
NUXT_DEV_PORT=4430
NUXT_DEV_SSL_KEY=./certs/bluelist-local.blue-key.pem
NUXT_DEV_SSL_CERT=./certs/bluelist-local.blue.pem

# Corporate proxy CA
NODE_EXTRA_CA_CERTS=./certs/bayer-proxy-ca.pem
```