### PR TITLE
feat(theme): city pop redesign — Poolside

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -204,4 +204,17 @@ lists are fetched so the slug is available for navigation.
   `src/types/index.ts`.
 - **Commits:** Conventional Commits, enforced by commitlint.
 
+## Design System
+
+Theming is CSS-custom-property driven: `:root` (dark) and `.light-theme` blocks in
+[`src/assets/styles/_variables.css`](../src/assets/styles/_variables.css), toggled by
+`ThemeToggle.vue`.
+
+- [Design token audit & target schema](design/token-schema.md) — current token defects and the
+  schema theme work targets.
+- [City pop visual research](design/city-pop-aesthetics.md) — aesthetic research backing the
+  proposed redesign.
+- [Theme proposals](themes/README.md) — six specs (3 families × dark/light) awaiting a
+  selection. Not yet implemented. Live previews: `open docs/themes/index.html`.
+
 See [CONTRIBUTING.md](../CONTRIBUTING.md) for setup and workflow details.

--- a/docs/design/city-pop-aesthetics.md
+++ b/docs/design/city-pop-aesthetics.md
@@ -1,0 +1,135 @@
+# Japanese City Pop — Visual Research
+
+Research backing the Bluelist visual redesign. Distils the city pop aesthetic into concrete
+UI levers so the theme proposals in [`docs/themes/`](../themes/README.md) are grounded in
+something other than taste.
+
+## Context
+
+City pop (シティ・ポップ) is a loosely defined Japanese pop genre that emerged mid-1970s and
+peaked in the 1980s — "urban pop music for those with urban lifestyles" (Yutaka Kimura). It
+was inextricably tied to Japan's tech-fuelled economic bubble and the wealthy new leisure
+class it created: the Walkman, car cassette decks, the Yamaha CS-80, the TR-808.
+
+Critically for us, **the genre is remembered visually as much as musically**. Its look was
+established by illustrators — above all **Hiroshi Nagai** (永井博), whose covers for Eiichi
+Ohtaki's _A Long Vacation_ (1981) and _Niagara Song Book_ define the canon: flat tropical
+Americana, swimming pools, palms, gradient skies, hard-edged pop-art planes, drawn under a
+declared David Hockney influence after travels through the US and Guam in 1973–75.
+
+The 2010s revival (Mariya Takeuchi's "Plastic Love", Miki Matsubara's "Mayonaka no Door")
+arrived through YouTube algorithms and carried a second visual layer with it: **vaporwave and
+future funk** — Memphis-Milano geometry, VHS degradation, glitch art, fullwidth characters
+(ＡＥＳＴＨＥＴＩＣ), 1990s web imagery, Greco-Roman statues. Future funk in particular samples
+city pop directly and borrows 1980s–90s anime imagery.
+
+Two distinct moods are therefore available to us, and they are not the same thing:
+
+|         | Daytime lineage                     | Nighttime lineage                      |
+| ------- | ----------------------------------- | -------------------------------------- |
+| Source  | Nagai / Ohtaki / resort AOR         | Plastic Love / vaporwave / future funk |
+| Palette | Aqua, coral, sun-yellow on sky blue | Magenta, cyan, violet on ink black     |
+| Feeling | Optimistic, spacious, sunlit        | Nocturnal, electric, nostalgic         |
+| Risk    | Can read as generic "flat design"   | Can read as meme / cliché              |
+
+A third, quieter lineage sits underneath both: **Showa retro** (昭和レトロ) — the kissaten
+coffee-shop, vinyl liner notes, 1970s Japanese print. Warm, literary, low-saturation. This is
+the least-exploited and most UI-appropriate register.
+
+## The eight actionable characteristics
+
+Each characteristic is paired with the specific UI lever it maps to. The theme proposals are
+scored against these.
+
+### 1. Gradient skies and time-of-day light
+
+Nagai's skies are vertical gradients — deep blue at the zenith falling to coral and gold at
+the horizon. The time of day _is_ the mood.
+
+**UI lever.** Page-background gradients, header washes, hero blocks. A theme picks a time of
+day and commits: noon (light) or dusk/midnight (dark). Applies to `--background-color` and the
+`AppHeader` surface.
+
+### 2. Flat, hard-edged geometry
+
+Pop-art flatness: solid colour planes, crisp boundaries, no texture inside a shape, no soft
+shading. Buildings, pools and palms are cut-out silhouettes.
+
+**UI lever.** Low or zero `border-radius`, solid fills over gradients on small elements,
+minimal blur on shadows. Argues _against_ the current 10px radius and soft `0 4px 6px` shadow.
+
+### 3. High-chroma tropical accents on a cool base
+
+A restrained cool ground (navy, charcoal, ink) carrying two or three very saturated accents:
+turquoise/aqua, coral/persimmon, sun-yellow, magenta.
+
+**UI lever.** A three-role colour system — **primary = cool** (the interactive colour),
+**secondary = warm** (counterpoint, emphasis), **tertiary/accent = highlight** (rare, high
+attention). Bluelist currently has these tokens but uses them inconsistently.
+
+### 4. Chrome, glass and water reflection
+
+Pool surfaces, car chrome, glass towers. Light is reflected, not diffused.
+
+**UI lever.** Subtle `linear-gradient` sheens on primary buttons and card headers — a single
+highlight band, not a full glossy gradient. Used sparingly; this is the easiest lever to
+overdo into skeuomorphism.
+
+### 5. Bilingual typographic pairing
+
+Sleeve typography pairs a Latin display face with Japanese kana/mincho, usually with wide
+letter-spacing on the romaji and the Japanese set much smaller as a secondary label.
+
+**UI lever.** A display font for headings with deliberate `letter-spacing`, plus optional
+Japanese micro-labels. **Decision: kana appear only as decorative micro-labels in section
+headers** — never as functional UI text, so no i18n burden is introduced.
+
+### 6. Horizon lines, rules and perspective grids
+
+Strong horizontal division of the frame; thin rules; the vaporwave perspective grid receding
+to a vanishing point.
+
+**UI lever.** Accent rules at the top of surfaces and between sections. Bluelist already has
+this motif — [`.data-card::before`](../../src/assets/styles/data-card.css) draws a 2px
+`--primary-color` bar across the top of every card. The redesign formalises it as a system
+rather than a one-off.
+
+### 7. Album-cover composition and negative space
+
+One focal subject, asymmetric placement, generous emptiness. A 12-inch sleeve is a
+low-density, high-impact format.
+
+**UI lever.** A larger spacing scale, wider page gutters, more room around cards. Bluelist
+currently hard-codes spacing per component (`0.75rem`, `1rem`, `16px`, `20px` all appear);
+a shared scale is a prerequisite.
+
+### 8. Analog nostalgia layer
+
+VHS tracking artifacts, print halftone and grain, chromatic fringing, neon bleed at night.
+This is the vaporwave contribution, and it is pure decoration.
+
+**UI lever.** Optional overlays and glow shadows. **Decision: every decorative overlay is
+opt-in behind a `[data-decor='on']` attribute on `<html>`**, defaulting to off. This keeps the
+aesthetic from taxing readability or paint performance, and makes it trivially removable.
+
+## Applying this to Bluelist specifically
+
+Bluelist is a list-management tool for Bluesky follows — dense, repetitive, read-heavy
+surfaces (`DataCard`, `MemberCard`, `ListChips`, `Pagination`). Two consequences:
+
+- **The aesthetic must live in the chrome, not the content.** Headers, buttons, rules, empty
+  states and accents carry the theme. Rows of handles and display names stay quiet and legible.
+- **The current global monospace is the wrong signal.** [`app.css`](../../src/assets/styles/app.css)
+  sets `body { font-family: var(--font-mono) }`, which reads as terminal/hacker, not as
+  1980s Tokyo leisure. All three proposals retain mono for **data** (handles, DIDs, counts,
+  URIs) and introduce a display face for headings and a humanist sans for body copy.
+
+## Sources
+
+- [City pop — Wikipedia](https://en.wikipedia.org/wiki/City_pop) — definitions, origins, the
+  tech-boom context, the 21st-century resurgence.
+- [Hiroshi Nagai — Wikipedia](https://en.wikipedia.org/wiki/Hiroshi_Nagai) — biography, the
+  Hockney/pop-art influence, _A Long Vacation_, influence on vaporwave.
+- [Vaporwave — Wikipedia](https://en.wikipedia.org/wiki/Vaporwave) — the visual aesthetic
+  (glitch art, Memphis Milano geometry, VHS degradation, fullwidth type), future funk's
+  sampling of city pop.

--- a/docs/design/token-schema.md
+++ b/docs/design/token-schema.md
@@ -1,0 +1,178 @@
+# Design Token Audit & Target Schema
+
+Two things live here:
+
+1. **The audit** — defects and gaps in the current token layer in
+   [`src/assets/styles/_variables.css`](../../src/assets/styles/_variables.css).
+2. **The target schema** — the contract every theme proposal in
+   [`docs/themes/`](../themes/README.md) fills in. Because all six proposals fill the same
+   schema, diffing any two of them shows only value changes.
+
+Nothing here has been applied to `src/`. This is specification only.
+
+## Current state
+
+Theming is entirely CSS-custom-property driven. `_variables.css` defines two blocks:
+
+- `:root` — dark theme (the default)
+- `.light-theme` — light theme
+
+[`ThemeToggle.vue`](../../src/components/ThemeToggle.vue) toggles the `light-theme` class on
+`document.documentElement` and persists the choice to `localStorage['theme']`. Twelve
+component stylesheets under `src/assets/styles/` consume the tokens across ~297 `var()` calls.
+
+**Consequence: shipping one chosen theme family requires no architectural change** — it is a
+replacement of the two token blocks. A theme _switcher_ (more than one family available at
+runtime) would be a separate change and is out of scope.
+
+## Audit findings
+
+### A. Tokens referenced but never defined
+
+Ten tokens are used in component CSS but declared in neither `:root` nor `.light-theme`. Each
+currently resolves to nothing, silently falling back to the property's initial value.
+
+| Token                       | Used in                              | Current effect                               |
+| --------------------------- | ------------------------------------ | -------------------------------------------- |
+| `--hover-bg`                | `data-card.css`                      | Card action buttons have no hover background |
+| `--card-bg`                 | `data-card.css`, `list-form.css`     | Modal and form panels are transparent        |
+| `--input-bg`                | `list-form.css`                      | Text inputs have no background fill          |
+| `--primary-transparent-15`  | `data-display.css`, `pagination.css` | Transparent instead of tinted                |
+| `--card-bg-transparent-30`  | `data-display.css`                   | Transparent                                  |
+| `--success-text`            | `data-display.css`                   | Falls back to inherited colour               |
+| `--error-text`              | `data-display.css`                   | Falls back to inherited colour               |
+| `--error-bg-transparent-10` | `data-display.css`                   | Transparent                                  |
+| `--error-hover-color`       | `data-card.css`                      | Destructive button has no hover state        |
+| `--button-text-color`       | `list-form.css`                      | Has a `white` fallback, so masked            |
+
+### B. Transparent variants do not match their base colour
+
+The `*-transparent-*` tokens were not updated when the base colours changed. They currently
+tint with a completely different hue.
+
+| Mode  | Base token          | Base value             | Transparent variant   | Variant hue    |
+| ----- | ------------------- | ---------------------- | --------------------- | -------------- |
+| Dark  | `--primary-color`   | `#a0d6ff` (light blue) | `rgba(255,158,100,…)` | Orange         |
+| Light | `--primary-color`   | `#1185e0` (blue)       | `rgba(211,100,255,…)` | Purple         |
+| Light | `--secondary-color` | `#ff7700` (orange)     | `rgba(92,204,150,…)`  | Green          |
+| Light | `--accent-color`    | `#7c5cff` (violet)     | `rgba(187,154,247,…)` | Lighter violet |
+
+This is why hover and focus states across the app tint toward colours that appear nowhere
+else. **Every proposal derives its transparent variants from its own base colour**, which
+fixes this as a side effect.
+
+### C. Mode-asymmetric tokens
+
+Defined in one mode only, so the other mode falls through to nothing:
+
+- `--success-bg`, `--error-bg` — light only
+- `--secondary-transparent-50` — dark only
+- `--card-shadow` — used by `--shadow` in `:root` but only _defined_ later in the light block
+  and in `:root` after first use
+
+### D. Missing scales
+
+No tokens exist for spacing, radius beyond a single value, typography, or motion timing.
+Values are hard-coded per file — `0.75rem`, `1rem`, `16px`, `20px`, `5px`, `8px` all appear as
+literals. `--border-radius: 10px` is defined once and then overridden to `0` in at least four
+places, meaning the token no longer describes reality.
+
+### E. Global monospace
+
+`app.css` sets `body { font-family: var(--font-mono), … }` and `--font-mono` is
+`'Courier New', Courier, monospace`. Only one font token exists. See
+[city-pop-aesthetics.md](city-pop-aesthetics.md#applying-this-to-bluelist-specifically) for
+why this is being changed.
+
+### F. Insufficient border contrast
+
+No current border colour reaches 3:1 against its background. That is acceptable for decorative
+separators but **not** for borders that are the only visual indicator of a form control
+(WCAG 2.1 SC 1.4.11 Non-text Contrast). The schema therefore splits borders into two tokens.
+
+## Target schema
+
+Every theme proposal defines all of the following. Tokens marked **new** do not exist today.
+
+### Colour — surfaces
+
+| Token                | Role                                                   | Requirement          |
+| -------------------- | ------------------------------------------------------ | -------------------- |
+| `--background-color` | Page background                                        | —                    |
+| `--card-color`       | Card / panel surface                                   | —                    |
+| `--card-bg`          | **new** alias of `--card-color`, for legacy call sites | —                    |
+| `--surface-raised`   | **new** Modals, dropdowns, elevated panels             | —                    |
+| `--input-bg`         | **new** Form field fill                                | —                    |
+| `--hover-bg`         | **new** Neutral hover wash                             | —                    |
+| `--border-color`     | Decorative separators, card outlines                   | —                    |
+| `--border-strong`    | **new** Form-control borders                           | ≥ 3:1 vs. background |
+| `--border-style`     | Composed: `1px solid var(--border-color)`              | —                    |
+
+### Colour — content
+
+| Token                 | Role                                   | Requirement                               |
+| --------------------- | -------------------------------------- | ----------------------------------------- |
+| `--text-color`        | Body copy                              | ≥ 4.5:1 vs. background _and_ card         |
+| `--text-light`        | Secondary copy, metadata               | ≥ 4.5:1 vs. background _and_ card         |
+| `--text-disabled`     | Inactive text                          | ≥ 3:1 (exempt under SC 1.4.3, met anyway) |
+| `--button-text-color` | **new** Text on filled primary buttons | ≥ 4.5:1 vs. `--primary-color`             |
+
+### Colour — brand roles
+
+Per [characteristic 3](city-pop-aesthetics.md#3-high-chroma-tropical-accents-on-a-cool-base):
+
+| Token               | Role                          | Requirement                       |
+| ------------------- | ----------------------------- | --------------------------------- |
+| `--primary-color`   | Interactive / cool            | ≥ 4.5:1 vs. background _and_ card |
+| `--primary-dark`    | Pressed and hover fills       | ≥ 4.5:1 vs. background _and_ card |
+| `--secondary-color` | Warm counterpoint, emphasis   | ≥ 4.5:1 vs. background _and_ card |
+| `--accent-color`    | Rare high-attention highlight | ≥ 4.5:1 vs. background _and_ card |
+
+### Colour — status
+
+`--success-color`, `--success-bg`, `--success-text`, `--error-color`, `--error-bg`,
+`--error-text`, `--error-hover-color`, `--disabled-color`. Both modes must define all of them.
+`--success-text` and `--error-text` require ≥ 4.5:1 against their paired `*-bg`.
+
+### Colour — alpha variants
+
+Derived from their own base, never from another hue:
+
+`--primary-transparent-10 / -15 / -20 / -30`, `--secondary-transparent-10 / -50`,
+`--accent-transparent-10 / -50`, `--card-bg-transparent-30 / -50 / -80`,
+`--text-light-transparent-20 / -30`, `--error-bg-transparent-10`, `--card-shadow`,
+`--spinner-bg`.
+
+### Typography — **new**
+
+`--font-display`, `--font-body`, `--font-mono`; `--text-xs` … `--text-3xl`;
+`--leading-tight / -normal / -relaxed`; `--tracking-tight / -normal / -wide / -wider`;
+`--weight-normal / -medium / -bold`.
+
+Mono is retained for **data only**: handles, DIDs, counts, URIs, timestamps.
+
+### Spacing and layout — **new**
+
+`--space-1` … `--space-8` on a consistent base unit, plus `--content-max-width`,
+`--page-gutter`, `--card-padding`, `--section-gap`.
+
+### Shape, elevation, motion — **new**
+
+`--radius-sm`, `--radius-md`, `--border-radius` (retained alias); `--shadow-sm`,
+`--shadow-md`, `--shadow-lg`, `--shadow` (retained alias), `--focus-ring`;
+`--duration-fast`, `--duration-base`, `--ease`, `--transition` (retained alias).
+
+### Decoration — **new, opt-in**
+
+`--decor-gradient`, `--decor-sheen`, `--decor-glow`, `--decor-overlay`.
+
+All decorative rules are scoped to `[data-decor='on']` on `<html>` and default to off, per
+[characteristic 8](city-pop-aesthetics.md#8-analog-nostalgia-layer).
+
+## Verification method
+
+Contrast figures quoted in the proposals were computed with the WCAG 2.1 relative-luminance
+formula against each theme's own `--background-color` and `--card-color`, and the reported
+ratio is the **lower** of the two. All six palettes pass the requirements in this schema —
+several values were darkened or lightened during authoring specifically to clear the
+thresholds, notably every `--border-strong` and all four light-mode `--text-disabled` values.

--- a/docs/themes/README.md
+++ b/docs/themes/README.md
@@ -1,0 +1,139 @@
+# Bluelist Theme Proposals — City Pop Redesign
+
+Six specifications: three theme families × dark and light. **Pick one family.** Nothing here
+has been applied to `src/` — these are proposals only.
+
+## ▶ Start here — live previews
+
+Open these in a browser. They render the real tokens on mock Bluelist surfaces, with working
+dark/light and decoration toggles.
+
+|                                                        |                                                            |
+| ------------------------------------------------------ | ---------------------------------------------------------- |
+| **[index.html](index.html)**                           | All six variants side by side — the fastest way to compare |
+| [theme-a-kissaten.html](theme-a-kissaten.html)         | Theme A, full preview                                      |
+| [theme-b-poolside.html](theme-b-poolside.html)         | Theme B, full preview                                      |
+| [theme-c-bayside-neon.html](theme-c-bayside-neon.html) | Theme C, full preview                                      |
+
+```sh
+open docs/themes/index.html
+```
+
+Each preview includes palette swatches with measured contrast, a type specimen, every button
+state, a mock header/card/member-row/chips/pagination/form, the spacing scale, and the full
+contrast record. The previews load fonts from Google Fonts for convenience; production is
+self-hosted WOFF2.
+
+Background reading:
+
+- [City pop visual research](../design/city-pop-aesthetics.md) — the eight characteristics
+  every proposal is scored against.
+- [Token audit & target schema](../design/token-schema.md) — current defects and the contract
+  all six proposals fill.
+
+## The six artifacts
+
+| Family                          | Dark                                                         | Light                                                          |
+| ------------------------------- | ------------------------------------------------------------ | -------------------------------------------------------------- |
+| **A — Kissaten** 喫茶店         | [theme-a-kissaten-dark.md](theme-a-kissaten-dark.md)         | [theme-a-kissaten-light.md](theme-a-kissaten-light.md)         |
+| **B — Poolside** プールサイド   | [theme-b-poolside-dark.md](theme-b-poolside-dark.md)         | [theme-b-poolside-light.md](theme-b-poolside-light.md)         |
+| **C — Bayside Neon** 湾岸ネオン | [theme-c-bayside-neon-dark.md](theme-c-bayside-neon-dark.md) | [theme-c-bayside-neon-light.md](theme-c-bayside-neon-light.md) |
+
+Each artifact has the same eleven sections in the same order, so diffing any two shows only
+value changes.
+
+## Comparison matrix
+
+|                            | **A — Kissaten**                               | **B — Poolside**                     | **C — Bayside Neon**                   |
+| -------------------------- | ---------------------------------------------- | ------------------------------------ | -------------------------------------- |
+| Intensity                  | Restrained / editorial                         | **Balanced**                         | Maximalist                             |
+| Reference                  | Showa kissaten, vinyl liner notes, 1970s print | Hiroshi Nagai pools & gradient skies | Midnight Tokyo, vaporwave, future funk |
+| Mood                       | Warm, quiet, literary                          | Bright, optimistic, spacious         | Electric, nocturnal, synthetic         |
+| Dark page                  | `#15120E` warm charcoal                        | `#0E1B2A` dusk navy                  | `#0A0614` ink violet-black             |
+| Light page                 | `#F5EFE3` aged paper                           | `#EAF6FA` pale sky                   | `#F6F0FA` lilac-white                  |
+| Primary (dark · light)     | `#E8A33D` · `#8A5416` amber                    | `#45D0E0` · `#00707F` aqua           | `#FF4DA6` · `#C2005E` magenta          |
+| Secondary                  | `#5FA398` · `#2F6B62` teal                     | `#FF8A6B` · `#C2410C` coral          | `#35E8FF` · `#006B85` cyan             |
+| Tertiary                   | `#D4674A` · `#9C3A22` persimmon                | `#FFD166` · `#8A5406` sun            | `#B96BFF` · `#6D28D9` violet           |
+| Display font               | Shippori Mincho B1 (serif)                     | Outfit (geometric sans)              | Chakra Petch (wide techno)             |
+| Type scale                 | 1.200 minor third                              | 1.250 major third                    | 1.333 perfect fourth                   |
+| Radius                     | `2px`                                          | `4px`                                | `0`                                    |
+| Spacing base               | `4px`                                          | `4px`                                | `8px`                                  |
+| Elevation                  | Hairline borders, near-flat                    | Soft shadow, 2px card lift           | Glow (dark) / hard offset (light)      |
+| Motion                     | `160ms`, colour only                           | `200ms`, buoyant lift                | `140ms`, sharp, no lift                |
+| Decoration                 | Paper grain                                    | Sky gradients, sheen                 | Scanlines, glow, grid horizon          |
+| CSS work beyond token swap | Minimal                                        | Small                                | **Significant**                        |
+| Risk                       | Lowest                                         | Low                                  | Highest                                |
+
+## How to choose
+
+Some questions that actually discriminate between these:
+
+**Should Bluelist feel like a document or an interface?** A treats the app as a printed page —
+serif headings, generous leading, hairlines. C treats it as signage. B sits between.
+
+**How much of the app is dense list content?** Bluelist is mostly repeating rows —
+`MemberCard`, `follows`, `Pagination`. The louder the theme, the more that repetition costs.
+A and B degrade gracefully at high density; C needs its decoration left off to do so.
+
+**Do you want the aesthetic legible to someone who doesn't know the reference?** B reads as
+"nice, bright, tropical" to anyone. A reads as "tasteful" without announcing itself. C reads
+as "vaporwave" specifically — which is either the point or the problem.
+
+**How much CSS work is acceptable?** A and B are essentially token swaps. C needs real
+structural changes: gradient rules can't be `border-color`, so `AppHeader` and the modal need
+new pseudo-elements, and the larger spacing scale reflows list density.
+
+If undecided, **B — Poolside** is the recommendation. It carries the most city pop
+characteristics (five of eight, including the gradient skies and tropical-accent structure
+that most define Nagai's work) at a cost close to A's.
+
+## What all six share
+
+Decisions applied uniformly, so they are not differentiators:
+
+- **Monospace is demoted.** Today `body` is `--font-mono`, which reads terminal, not city pop.
+  All three families keep mono for **data only** — handles, DIDs, counts, URIs, timestamps —
+  and add a display face for headings plus Inter for body copy.
+- **Latin only.** Japanese micro-labels were proposed and then dropped during implementation;
+  the aesthetic is carried by colour, type and layout. Themes A and C below still describe
+  them, as originally proposed.
+- **Decoration is opt-in.** Every gradient, grain, glow, scanline and sheen sits behind
+  `[data-decor='on']` on `<html>` and defaults to off.
+- **Fonts are self-hosted** via the `@nuxt/fonts` module — subset, `font-display: swap`,
+  no third-party request at runtime.
+- **All text clears WCAG AA.** Body and brand colours ≥ 4.5:1 against both page and card;
+  disabled text and form-control borders ≥ 3:1.
+- **The audit bugs are fixed as a side effect.** Every proposal derives its alpha variants from
+  its own base colour and defines all ten currently-undefined tokens. See the
+  [audit](../design/token-schema.md#audit-findings).
+
+## Verified contrast
+
+Every value was computed with the WCAG 2.1 relative-luminance formula against that theme's own
+`--background-color` and `--card-color`; the reported figure is the **lower** of the two. All
+six palettes pass. Several values were adjusted during authoring specifically to clear the
+thresholds:
+
+| Adjustment                                        | Reason                                                                                       |
+| ------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| All six `--border-strong` values introduced       | No existing border reached 3:1; form-control borders need it (SC 1.4.11)                     |
+| Four light-mode `--text-disabled` values darkened | Original picks sat at 2.4–2.8:1                                                              |
+| A-light primary `#B4762A` → `#8A5416`             | 4.27:1 was large-text only                                                                   |
+| B-light accent `#A16207` → `#8A5406`              | Marginal at 4.47:1                                                                           |
+| C-dark `--primary-dark` `#D62E85` → `#E8479A`     | 4.37:1; brightened rather than darkened, since a darker pressed state vanishes on near-black |
+| A-dark error `#D9584E` → `#E0655A`                | Landed exactly on the 4.50 boundary                                                          |
+
+## Next step
+
+Choose a family. Implementation is then:
+
+1. Replace the `:root` and `.light-theme` blocks in
+   [`_variables.css`](../../src/assets/styles/_variables.css) with that family's two token maps.
+2. Add the self-hosted fonts and switch `body` in
+   [`app.css`](../../src/assets/styles/app.css) from `--font-mono` to `--font-body`.
+3. Work through the chosen artifact's **Migration notes** section.
+4. Sweep the twelve component stylesheets for hard-coded spacing and radius.
+
+No change to [`ThemeToggle.vue`](../../src/components/ThemeToggle.vue) is needed — it toggles
+the `light-theme` class, which is exactly the mechanism these proposals target. A runtime
+switcher offering more than one family at once would be a separate piece of work.

--- a/docs/themes/index.html
+++ b/docs/themes/index.html
@@ -1,0 +1,656 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Bluelist — City Pop Theme Proposals</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@700&family=IBM+Plex+Mono&family=Inter:wght@400;500;600&family=Outfit:wght@500;700&family=Shippori+Mincho+B1:wght@400;600&family=Zen+Kaku+Gothic+New:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* ── page shell (neutral, so it doesn't bias the comparison) ──── */
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family: 'Inter', system-ui, sans-serif;
+        background: #101114;
+        color: #e8e9ec;
+        line-height: 1.6;
+      }
+      .page {
+        max-width: 1400px;
+        margin: 0 auto;
+        padding: 48px 32px 96px;
+      }
+      h1 {
+        font-size: 2rem;
+        line-height: 1.2;
+        margin-bottom: 8px;
+      }
+      .sub {
+        color: #9aa0ab;
+        max-width: 70ch;
+        margin-bottom: 8px;
+      }
+      h2 {
+        font-size: 1.4rem;
+        margin: 56px 0 4px;
+      }
+      .h2sub {
+        color: #9aa0ab;
+        margin-bottom: 20px;
+        max-width: 70ch;
+      }
+      a {
+        color: #7cc4ff;
+      }
+      code {
+        font-family: 'IBM Plex Mono', monospace;
+        font-size: 0.85em;
+        color: #b9c0cc;
+      }
+
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(380px, 1fr));
+        gap: 24px;
+      }
+
+      /* ── each tile is a self-contained theme scope ─────────────────── */
+      .t {
+        border: 1px solid #262a31;
+        border-radius: 8px;
+        overflow: hidden;
+        background: var(--background-color);
+        color: var(--text-color);
+        font-family: var(--font-body);
+      }
+      .t__label {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 8px 14px;
+        background: #1a1c21;
+        color: #e8e9ec;
+        font-size: 0.78rem;
+        font-family: 'IBM Plex Mono', monospace;
+        border-bottom: 1px solid #262a31;
+      }
+      .t__label b {
+        font-weight: 500;
+      }
+      .t__mode {
+        margin-left: auto;
+        color: #9aa0ab;
+      }
+      .t__inner {
+        padding: 18px;
+      }
+
+      .t__head {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding-bottom: 12px;
+        margin-bottom: 14px;
+        border-bottom: 1px solid var(--border-color);
+        position: relative;
+      }
+      .t__logo {
+        font-family: var(--font-display);
+        font-weight: var(--display-weight);
+        font-size: 1.15rem;
+        color: var(--primary-color);
+        letter-spacing: var(--tracking-wide);
+        text-transform: var(--display-case);
+        margin-right: auto;
+      }
+      .t__who {
+        font-family: var(--font-mono);
+        font-size: 0.7rem;
+        color: var(--text-light);
+        display: flex;
+        align-items: center;
+        gap: 6px;
+      }
+      .dot {
+        width: 7px;
+        height: 7px;
+        background: var(--success-color);
+        border-radius: var(--dot-radius);
+      }
+
+      .t__card {
+        position: relative;
+        background: var(--card-color);
+        border: 1px solid var(--border-color);
+        border-radius: var(--radius);
+        box-shadow: var(--shadow);
+        padding: var(--card-padding);
+        margin-bottom: 12px;
+      }
+      .t__card::before {
+        content: '';
+        position: absolute;
+        inset: 0 0 auto 0;
+        height: var(--rule-h);
+        background: var(--primary-color);
+        background-image: var(--rule-img);
+      }
+      .t__title {
+        font-family: var(--font-display);
+        font-weight: var(--display-weight);
+        font-size: 1.15rem;
+        line-height: 1.2;
+        letter-spacing: var(--tracking-wide);
+        text-transform: var(--display-case);
+      }
+      .t__meta {
+        font-family: var(--font-mono);
+        font-size: 0.72rem;
+        color: var(--text-light);
+        margin: 2px 0 12px;
+      }
+      .t__row {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 7px 0;
+      }
+      .t__av {
+        width: 26px;
+        height: 26px;
+        border-radius: var(--dot-radius);
+        background: var(--primary-t20);
+        border: 1px solid var(--primary-color);
+        flex: none;
+      }
+      .t__name {
+        font-size: 0.88rem;
+        font-weight: 500;
+      }
+      .t__handle {
+        font-family: var(--font-mono);
+        font-size: 0.7rem;
+        color: var(--text-light);
+      }
+
+      .t__btns {
+        display: flex;
+        gap: 8px;
+        margin-top: 12px;
+        flex-wrap: wrap;
+      }
+      .t__btn {
+        font-family: var(--font-body);
+        font-size: 0.8rem;
+        font-weight: 500;
+        border: none;
+        border-radius: var(--radius);
+        padding: 8px 14px;
+        cursor: pointer;
+      }
+      .t__btn--p {
+        background: var(--primary-color);
+        background-image: var(--brand-img);
+        color: var(--button-text-color);
+      }
+      .t__btn--s {
+        background: var(--primary-t10);
+        border: 1px solid var(--primary-color);
+        color: var(--primary-color);
+      }
+      .t__chips {
+        display: flex;
+        gap: 6px;
+        margin-top: 12px;
+        flex-wrap: wrap;
+      }
+      .t__chip {
+        font-family: var(--font-mono);
+        font-size: 0.7rem;
+        background: var(--primary-t10);
+        border: 1px solid var(--primary-color);
+        border-radius: var(--radius);
+        color: var(--primary-color);
+        padding: 3px 8px;
+      }
+      .t__chip--2 {
+        background: transparent;
+        border-color: var(--secondary-color);
+        color: var(--secondary-color);
+      }
+      .t__chip--3 {
+        background: transparent;
+        border-color: var(--accent-color);
+        color: var(--accent-color);
+      }
+
+      .t__sw {
+        display: flex;
+        margin-top: 14px;
+        border-radius: var(--radius);
+        overflow: hidden;
+      }
+      .t__sw i {
+        flex: 1;
+        height: 26px;
+      }
+
+      /* ── THEME A · KISSATEN ────────────────────────────────────────── */
+      .t[data-t='a'] {
+        --font-display: 'Shippori Mincho B1', Georgia, serif;
+        --font-body: 'Inter', sans-serif;
+        --font-mono: 'IBM Plex Mono', monospace;
+        --display-weight: 400;
+        --display-case: none;
+        --tracking-wide: 0.02em;
+        --radius: 2px;
+        --rule-h: 2px;
+        --rule-img: none;
+        --brand-img: none;
+        --dot-radius: 50%;
+        --card-padding: 18px;
+      }
+      .t[data-t='a'][data-m='dark'] {
+        --background-color: #15120e;
+        --card-color: #1e1a15;
+        --border-color: #3a3025;
+        --text-color: #ede6d8;
+        --text-light: #a89b85;
+        --button-text-color: #15120e;
+        --primary-color: #e8a33d;
+        --secondary-color: #5fa398;
+        --accent-color: #d4674a;
+        --success-color: #6fa76b;
+        --primary-t10: rgba(232, 163, 61, 0.1);
+        --primary-t20: rgba(232, 163, 61, 0.2);
+        --shadow: none;
+      }
+      .t[data-t='a'][data-m='light'] {
+        --background-color: #f5efe3;
+        --card-color: #fffbf2;
+        --border-color: #ddd2be;
+        --text-color: #211c15;
+        --text-light: #6b6155;
+        --button-text-color: #fffbf2;
+        --primary-color: #8a5416;
+        --secondary-color: #2f6b62;
+        --accent-color: #9c3a22;
+        --success-color: #2f6b3a;
+        --primary-t10: rgba(138, 84, 22, 0.1);
+        --primary-t20: rgba(138, 84, 22, 0.2);
+        --shadow: 0 1px 2px rgba(60, 45, 25, 0.12);
+        --display-weight: 600;
+      }
+
+      /* ── THEME B · POOLSIDE ────────────────────────────────────────── */
+      .t[data-t='b'] {
+        --font-display: 'Outfit', sans-serif;
+        --font-body: 'Inter', sans-serif;
+        --font-mono: 'IBM Plex Mono', monospace;
+        --display-weight: 700;
+        --display-case: uppercase;
+        --tracking-wide: 0.06em;
+        --radius: 4px;
+        --rule-h: 2px;
+        --rule-img: none;
+        --brand-img: none;
+        --dot-radius: 50%;
+        --card-padding: 18px;
+      }
+      .t[data-t='b'][data-m='dark'] {
+        --background-color: #0e1b2a;
+        --card-color: #16283c;
+        --border-color: #2a4767;
+        --text-color: #e6f1f7;
+        --text-light: #93afc6;
+        --button-text-color: #0e1b2a;
+        --primary-color: #45d0e0;
+        --secondary-color: #ff8a6b;
+        --accent-color: #ffd166;
+        --success-color: #4fd1a0;
+        --primary-t10: rgba(69, 208, 224, 0.1);
+        --primary-t20: rgba(69, 208, 224, 0.2);
+        --shadow: 0 1px 2px rgba(0, 10, 20, 0.45);
+      }
+      .t[data-t='b'][data-m='light'] {
+        --background-color: #eaf6fa;
+        --card-color: #ffffff;
+        --border-color: #c3dee9;
+        --text-color: #0f2233;
+        --text-light: #4e6b7d;
+        --button-text-color: #ffffff;
+        --primary-color: #00707f;
+        --secondary-color: #c2410c;
+        --accent-color: #8a5406;
+        --success-color: #12694f;
+        --primary-t10: rgba(0, 112, 127, 0.1);
+        --primary-t20: rgba(0, 112, 127, 0.2);
+        --shadow: 0 1px 2px rgba(15, 34, 51, 0.1);
+      }
+
+      /* ── THEME C · BAYSIDE NEON ────────────────────────────────────── */
+      .t[data-t='c'] {
+        --font-display: 'Chakra Petch', sans-serif;
+        --font-body: 'Inter', sans-serif;
+        --font-mono: 'IBM Plex Mono', monospace;
+        --display-weight: 700;
+        --display-case: uppercase;
+        --tracking-wide: 0.12em;
+        --radius: 0;
+        --rule-h: 3px;
+        --dot-radius: 0;
+        --card-padding: 18px;
+      }
+      .t[data-t='c'][data-m='dark'] {
+        --background-color: #0a0614;
+        --card-color: #150e24;
+        --border-color: #3a2260;
+        --text-color: #f2e9ff;
+        --text-light: #a896c9;
+        --button-text-color: #0a0614;
+        --primary-color: #ff4da6;
+        --secondary-color: #35e8ff;
+        --accent-color: #b96bff;
+        --success-color: #3de8b0;
+        --primary-t10: rgba(255, 77, 166, 0.1);
+        --primary-t20: rgba(255, 77, 166, 0.2);
+        --shadow: 0 4px 16px rgba(0, 0, 0, 0.6);
+        --rule-img: linear-gradient(90deg, #ff4da6, #35e8ff);
+        --brand-img: linear-gradient(90deg, #ff4da6, #b96bff);
+      }
+      .t[data-t='c'][data-m='light'] {
+        --background-color: #f6f0fa;
+        --card-color: #ffffff;
+        --border-color: #e2d0f0;
+        --text-color: #1a0e2e;
+        --text-light: #6b5b85;
+        --button-text-color: #ffffff;
+        --primary-color: #c2005e;
+        --secondary-color: #006b85;
+        --accent-color: #6d28d9;
+        --success-color: #0f6b4f;
+        --primary-t10: rgba(194, 0, 94, 0.1);
+        --primary-t20: rgba(194, 0, 94, 0.2);
+        --shadow: 0 1px 0 rgba(26, 14, 46, 0.16);
+        --rule-img: linear-gradient(90deg, #c2005e, #006b85);
+        --brand-img: linear-gradient(90deg, #c2005e, #6d28d9);
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.85rem;
+        margin-top: 8px;
+      }
+      th,
+      td {
+        text-align: left;
+        padding: 9px 12px;
+        border-bottom: 1px solid #262a31;
+        vertical-align: top;
+      }
+      th {
+        color: #9aa0ab;
+        font-weight: 500;
+      }
+      td:first-child {
+        color: #9aa0ab;
+        white-space: nowrap;
+      }
+      .rec {
+        display: inline-block;
+        font-size: 0.7rem;
+        background: #1d3a2a;
+        color: #6ee7a8;
+        border-radius: 3px;
+        padding: 1px 7px;
+        margin-left: 6px;
+        vertical-align: middle;
+      }
+      .links {
+        display: flex;
+        gap: 20px;
+        flex-wrap: wrap;
+        margin-top: 20px;
+        font-size: 0.9rem;
+      }
+      footer {
+        margin-top: 72px;
+        padding-top: 24px;
+        border-top: 1px solid #262a31;
+        color: #9aa0ab;
+        font-size: 0.85rem;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="page">
+      <h1>Bluelist — City Pop Theme Proposals</h1>
+      <p class="sub">
+        Three families, each in dark and light. All six are shown live below
+        with the real tokens. Pick one family — nothing has been applied to
+        <code>src/</code> yet.
+      </p>
+      <div class="links">
+        <a href="theme-a-kissaten.html">→ Theme A full preview</a>
+        <a href="theme-b-poolside.html">→ Theme B full preview</a>
+        <a href="theme-c-bayside-neon.html">→ Theme C full preview</a>
+        <a href="README.md">→ Written specs</a>
+        <a href="../design/city-pop-aesthetics.md">→ Research</a>
+      </div>
+
+      <h2>Dark mode</h2>
+      <p class="h2sub">The default. Bluelist ships dark-first.</p>
+      <div class="grid" id="dark"></div>
+
+      <h2>Light mode</h2>
+      <p class="h2sub">
+        Note how each family has to re-derive its brand colour for a light
+        ground — bright aqua and neon magenta are unreadable as text on white,
+        so B and C invert into deep, saturated ink versions.
+      </p>
+      <div class="grid" id="light"></div>
+
+      <h2>At a glance</h2>
+      <table>
+        <tr>
+          <th></th>
+          <th>A — Kissaten 喫茶店</th>
+          <th>B — Poolside プールサイド</th>
+          <th>C — Bayside Neon 湾岸ネオン</th>
+        </tr>
+        <tr>
+          <td>Intensity</td>
+          <td>Restrained / editorial</td>
+          <td>Balanced <span class="rec">recommended</span></td>
+          <td>Maximalist</td>
+        </tr>
+        <tr>
+          <td>Reference</td>
+          <td>Showa kissaten, vinyl liner notes</td>
+          <td>Hiroshi Nagai pools &amp; skies</td>
+          <td>Midnight Tokyo, vaporwave</td>
+        </tr>
+        <tr>
+          <td>Display font</td>
+          <td>Shippori Mincho B1 (serif)</td>
+          <td>Outfit (geometric sans)</td>
+          <td>Chakra Petch (wide techno)</td>
+        </tr>
+        <tr>
+          <td>Type scale</td>
+          <td>1.200 minor third</td>
+          <td>1.250 major third</td>
+          <td>1.333 perfect fourth</td>
+        </tr>
+        <tr>
+          <td>Radius</td>
+          <td>2px</td>
+          <td>4px</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <td>Spacing base</td>
+          <td>4px</td>
+          <td>4px</td>
+          <td>8px</td>
+        </tr>
+        <tr>
+          <td>Elevation</td>
+          <td>Hairlines, near-flat</td>
+          <td>Soft shadow, 2px lift</td>
+          <td>Glow (dark) / hard offset (light)</td>
+        </tr>
+        <tr>
+          <td>Decoration</td>
+          <td>Paper grain</td>
+          <td>Sky gradients, sheen</td>
+          <td>Scanlines, glow, grid horizon</td>
+        </tr>
+        <tr>
+          <td>CSS work</td>
+          <td>Token swap</td>
+          <td>Token swap</td>
+          <td>Token swap + new pseudo-elements</td>
+        </tr>
+        <tr>
+          <td>Risk</td>
+          <td>Lowest</td>
+          <td>Low</td>
+          <td>Highest</td>
+        </tr>
+      </table>
+
+      <h2>How to choose</h2>
+      <p class="h2sub">
+        <b>Document or interface?</b> A treats the app as a printed page. C
+        treats it as signage. B sits between.<br />
+        <b>How much is dense list content?</b> Bluelist is mostly repeating
+        rows. The louder the theme, the more that repetition costs.<br />
+        <b>Should the reference be legible to outsiders?</b> B reads as "bright
+        and tropical" to anyone. C reads as "vaporwave" specifically — the
+        point, or the problem.
+      </p>
+
+      <footer>
+        All six palettes pass WCAG AA: body and brand colours ≥ 4.5:1 against
+        both page and card, disabled text and control borders ≥ 3:1. Fonts load
+        from Google Fonts in this preview only; production is self-hosted WOFF2,
+        subset, <code>font-display: swap</code>.
+      </footer>
+    </div>
+
+    <script>
+      const FAMILIES = [
+        { k: 'a', name: 'Kissaten 喫茶店', tag: 'restrained' },
+        { k: 'b', name: 'Poolside プールサイド', tag: 'balanced' },
+        { k: 'c', name: 'Bayside Neon 湾岸ネオン', tag: 'maximalist' },
+      ];
+      const SWATCH = {
+        'a-dark': [
+          '#15120E',
+          '#1E1A15',
+          '#3A3025',
+          '#E8A33D',
+          '#5FA398',
+          '#D4674A',
+        ],
+        'a-light': [
+          '#F5EFE3',
+          '#FFFBF2',
+          '#DDD2BE',
+          '#8A5416',
+          '#2F6B62',
+          '#9C3A22',
+        ],
+        'b-dark': [
+          '#0E1B2A',
+          '#16283C',
+          '#2A4767',
+          '#45D0E0',
+          '#FF8A6B',
+          '#FFD166',
+        ],
+        'b-light': [
+          '#EAF6FA',
+          '#FFFFFF',
+          '#C3DEE9',
+          '#00707F',
+          '#C2410C',
+          '#8A5406',
+        ],
+        'c-dark': [
+          '#0A0614',
+          '#150E24',
+          '#3A2260',
+          '#FF4DA6',
+          '#35E8FF',
+          '#B96BFF',
+        ],
+        'c-light': [
+          '#F6F0FA',
+          '#FFFFFF',
+          '#E2D0F0',
+          '#C2005E',
+          '#006B85',
+          '#6D28D9',
+        ],
+      };
+
+      function tile(f, mode) {
+        const sw = SWATCH[f.k + '-' + mode]
+          .map((c) => `<i style="background:${c}"></i>`)
+          .join('');
+        return `
+        <div class="t" data-t="${f.k}" data-m="${mode}">
+          <div class="t__label"><b>${f.name}</b> · ${f.tag}<span class="t__mode">${mode}</span></div>
+          <div class="t__inner">
+            <div class="t__head">
+              <div class="t__logo">bluelist</div>
+              <div class="t__who"><span class="dot"></span>@samuel.bsky.social</div>
+            </div>
+            <div class="t__card">
+              <div class="t__title">Design Folks</div>
+              <div class="t__meta">42 members · updated 3d ago</div>
+              <div class="t__row">
+                <div class="t__av"></div>
+                <div><div class="t__name">Mariya Takeuchi</div>
+                <div class="t__handle">@mariya.bsky.social</div></div>
+              </div>
+              <div class="t__row">
+                <div class="t__av"></div>
+                <div><div class="t__name">Tatsuro Yamashita</div>
+                <div class="t__handle">@tatsuro.bsky.social</div></div>
+              </div>
+              <div class="t__chips">
+                <span class="t__chip">primary</span>
+                <span class="t__chip t__chip--2">secondary</span>
+                <span class="t__chip t__chip--3">tertiary</span>
+              </div>
+              <div class="t__btns">
+                <button class="t__btn t__btn--p">View list</button>
+                <button class="t__btn t__btn--s">Curate</button>
+              </div>
+            </div>
+            <div class="t__sw">${sw}</div>
+          </div>
+        </div>`;
+      }
+
+      document.getElementById('dark').innerHTML = FAMILIES.map((f) =>
+        tile(f, 'dark')
+      ).join('');
+      document.getElementById('light').innerHTML = FAMILIES.map((f) =>
+        tile(f, 'light')
+      ).join('');
+    </script>
+  </body>
+</html>

--- a/docs/themes/theme-a-kissaten-dark.md
+++ b/docs/themes/theme-a-kissaten-dark.md
@@ -1,0 +1,318 @@
+# Theme A — Kissaten 喫茶店 · Dark
+
+> **Mood:** a 1970s Tokyo coffee shop at night. Warm charcoal, amber lamplight, muted teal.
+> Quiet, literary, unhurried.
+
+|           |                                                                                                                                                                                                                                                                                                                                                                              |
+| --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Family    | A — Kissaten (喫茶店, "coffee house")                                                                                                                                                                                                                                                                                                                                        |
+| Mode      | Dark                                                                                                                                                                                                                                                                                                                                                                         |
+| Intensity | **Restrained / editorial** — lowest risk of the three                                                                                                                                                                                                                                                                                                                        |
+| Lineage   | Showa retro (昭和レトロ) — vinyl liner notes, 1970s Japanese print                                                                                                                                                                                                                                                                                                           |
+| Leans on  | [#2 flat geometry](../design/city-pop-aesthetics.md#2-flat-hard-edged-geometry), [#5 bilingual type](../design/city-pop-aesthetics.md#5-bilingual-typographic-pairing), [#6 horizon rules](../design/city-pop-aesthetics.md#6-horizon-lines-rules-and-perspective-grids), [#7 negative space](../design/city-pop-aesthetics.md#7-album-cover-composition-and-negative-space) |
+| Avoids    | Gradients, glow, chrome, scanlines                                                                                                                                                                                                                                                                                                                                           |
+
+## Typography
+
+Mincho serif for headings is the strongest Showa-retro signal available and costs nothing in
+legibility, because it is confined to headings.
+
+| Element                            | Value                                                                  |
+| ---------------------------------- | ---------------------------------------------------------------------- |
+| Display / headings                 | `Shippori Mincho B1` — serif, covers Latin + kana                      |
+| Body                               | `Inter`                                                                |
+| Data (handles, DIDs, counts, URIs) | `IBM Plex Mono`                                                        |
+| Fallback stack                     | `Georgia, serif` / `system-ui, sans-serif` / `ui-monospace, monospace` |
+| Weights loaded                     | Mincho 400/600 · Inter 400/500/600 · Plex Mono 400                     |
+| Delivery                           | Self-hosted WOFF2, `font-display: swap`, subset to Latin + kana used   |
+| Base size                          | `16px`                                                                 |
+| Scale ratio                        | **1.200** (minor third) — gentle, editorial                            |
+| `--text-3xl`                       | `2.074rem` / 33px — page title                                         |
+| `--text-2xl`                       | `1.728rem` / 27.6px — h2                                               |
+| `--text-xl`                        | `1.440rem` / 23px — h3                                                 |
+| `--text-lg`                        | `1.200rem` / 19.2px — h4, card title                                   |
+| `--text-base`                      | `1rem` / 16px — body                                                   |
+| `--text-sm`                        | `0.833rem` / 13.3px — metadata                                         |
+| `--text-xs`                        | `0.694rem` / 11.1px — kana micro-labels                                |
+| Line height                        | Headings `1.25` · body `1.7` (generous, print-like)                    |
+| Tracking                           | Display `0.02em` · body `0` · kana label `0.24em`                      |
+| Casing                             | No uppercase transforms; mincho reads poorly in caps                   |
+
+**Kana micro-labels.** Section headers may carry a small kana label above the Latin heading,
+at `--text-xs` / `--tracking-wider` / `--text-light`. Decorative only — never functional text.
+
+## Colour
+
+Ratios are measured against `--background-color` and `--card-color`; the lower is shown.
+Target is ≥ 4.5:1 for text and brand roles, ≥ 3:1 for disabled text and control borders.
+
+### Surfaces
+
+| Token                        | Value                   | Role                   | Contrast | Verdict    |
+| ---------------------------- | ----------------------- | ---------------------- | -------- | ---------- |
+| `--background-color`         | `#15120E`               | Page — warm near-black | —        | —          |
+| `--card-color` / `--card-bg` | `#1E1A15`               | Card, panel            | —        | —          |
+| `--surface-raised`           | `#262019`               | Modal, dropdown        | —        | —          |
+| `--input-bg`                 | `#12100C`               | Field fill — recessed  | —        | —          |
+| `--hover-bg`                 | `rgba(232,163,61,0.08)` | Neutral hover wash     | —        | —          |
+| `--border-color`             | `#3A3025`               | Decorative separators  | 1.45     | decorative |
+| `--border-strong`            | `#7C6F5D`               | Form-control borders   | **3.53** | ✅ AA      |
+
+### Content
+
+| Token                 | Value     | Role                  | Contrast  | Verdict |
+| --------------------- | --------- | --------------------- | --------- | ------- |
+| `--text-color`        | `#EDE6D8` | Body — warm off-white | **13.93** | ✅ AA   |
+| `--text-light`        | `#A89B85` | Metadata, handles     | **6.34**  | ✅ AA   |
+| `--text-disabled`     | `#7A6F60` | Inactive              | **3.52**  | ✅ (≥3) |
+| `--button-text-color` | `#15120E` | On amber fill         | **8.02**  | ✅ AA   |
+
+### Brand roles
+
+| Token               | Value     | Role                          | Contrast | Verdict |
+| ------------------- | --------- | ----------------------------- | -------- | ------- |
+| `--primary-color`   | `#E8A33D` | Amber lamplight — interactive | **8.02** | ✅ AA   |
+| `--primary-dark`    | `#C4832A` | Pressed / hover fill          | **5.46** | ✅ AA   |
+| `--secondary-color` | `#5FA398` | Muted teal — counterpoint     | **5.91** | ✅ AA   |
+| `--accent-color`    | `#D4674A` | Persimmon 柿 — rare highlight | **4.81** | ✅ AA   |
+
+### Status
+
+| Token                                | Value                    | Contrast | Verdict   |
+| ------------------------------------ | ------------------------ | -------- | --------- |
+| `--success-color` / `--success-text` | `#6FA76B`                | **6.11** | ✅ AA     |
+| `--success-bg`                       | `rgba(111,167,107,0.12)` | —        | —         |
+| `--error-color` / `--error-text`     | `#E0655A`                | **5.09** | ✅ AA     |
+| `--error-bg`                         | `rgba(224,101,90,0.12)`  | —        | —         |
+| `--error-hover-color`                | `#C24A40`                | —        | fill only |
+| `--disabled-color`                   | `#3A3025`                | —        | —         |
+
+### Alpha variants
+
+All derived from this theme's own bases — fixes [audit finding B](../design/token-schema.md#b-transparent-variants-do-not-match-their-base-colour).
+
+| Token                                        | Value                                     |
+| -------------------------------------------- | ----------------------------------------- |
+| `--primary-transparent-10 / -15 / -20 / -30` | `rgba(232,163,61, .10 / .15 / .20 / .30)` |
+| `--secondary-transparent-10 / -50`           | `rgba(95,163,152, .10 / .50)`             |
+| `--accent-transparent-10 / -50`              | `rgba(212,103,74, .10 / .50)`             |
+| `--card-bg-transparent-30 / -50 / -80`       | `rgba(30,26,21, .30 / .50 / .80)`         |
+| `--text-light-transparent-20 / -30`          | `rgba(168,155,133, .20 / .30)`            |
+| `--error-bg-transparent-10`                  | `rgba(224,101,90,0.10)`                   |
+| `--card-shadow`                              | `rgba(0,0,0,0.45)`                        |
+| `--spinner-bg`                               | `rgba(168,155,133,0.15)`                  |
+
+## Buttons
+
+Flat fills, 2px radius, hairline borders. No gradients.
+
+| Variant     | Fill                       | Border                | Text              | Radius | Padding     | Hover                                  | Active            | Focus                   |
+| ----------- | -------------------------- | --------------------- | ----------------- | ------ | ----------- | -------------------------------------- | ----------------- | ----------------------- |
+| Primary     | `--primary-color`          | none                  | `#15120E`         | `2px`  | `10px 18px` | fill → `--primary-dark`                | `translateY(1px)` | `0 0 0 2px` @ 30% amber |
+| Secondary   | `--primary-transparent-10` | `1px --primary-color` | `--primary-color` | `2px`  | `10px 18px` | fill → 20%                             | `translateY(1px)` | same                    |
+| Ghost       | transparent                | `1px --border-strong` | `--text-color`    | `2px`  | `10px 18px` | fill → `--hover-bg`                    | `translateY(1px)` | same                    |
+| Destructive | `--error-color`            | none                  | `#15120E`         | `2px`  | `10px 18px` | fill → `--error-hover-color`           | `translateY(1px)` | `0 0 0 2px` @ 30% red   |
+| Disabled    | `--disabled-color`         | none                  | `--text-disabled` | `2px`  | `10px 18px` | none                                   | none              | none                    |
+| Icon-only   | transparent                | none                  | `--text-light`    | `2px`  | `6px`       | `--hover-bg`, text → `--primary-color` | —                 | same                    |
+
+## Spacing & layout
+
+| Token                     | Value                                                   |
+| ------------------------- | ------------------------------------------------------- |
+| Base unit                 | `4px`                                                   |
+| `--space-1` … `--space-8` | `4 · 8 · 12 · 16 · 24 · 32 · 48 · 64px`                 |
+| `--card-padding`          | `--space-5` (24px)                                      |
+| `--section-gap`           | `--space-7` (48px)                                      |
+| `--page-gutter`           | `--space-6` (32px), `--space-4` (16px) below 1100px     |
+| `--content-max-width`     | `1100px` — narrower than today's 1200px, more editorial |
+| Card list gap             | `--space-3` (12px)                                      |
+| Breakpoints               | `1100px`, `720px`                                       |
+
+## Blocks & surfaces
+
+| Block            | Background                 | Border                      | Radius | Shadow        | Accent rule                    | Hover                      |
+| ---------------- | -------------------------- | --------------------------- | ------ | ------------- | ------------------------------ | -------------------------- |
+| Page             | `--background-color`       | —                           | —      | —             | —                              | —                          |
+| `DataCard`       | `--card-color`             | `1px --border-color`        | `2px`  | none          | 2px top bar, `--primary-color` | border → `--primary-color` |
+| `MemberCard`     | `--card-color`             | `1px --border-color`        | `2px`  | none          | none                           | `--hover-bg`               |
+| Modal            | `--surface-raised`         | `1px --border-strong`       | `2px`  | `--shadow-lg` | none                           | —                          |
+| `AppHeader`      | `--background-color`       | bottom `1px --border-color` | —      | none          | none                           | —                          |
+| `ListChips` chip | `--primary-transparent-10` | `1px --primary-color`       | `2px`  | none          | none                           | fill → 20%                 |
+| `Pagination`     | transparent                | top `1px --border-color`    | —      | none          | none                           | —                          |
+| Form input       | `--input-bg`               | `1px --border-strong`       | `2px`  | none          | none                           | border → `--primary-color` |
+| `LoginForm`      | `--card-color`             | `1px --border-color`        | `2px`  | `--shadow-md` | 2px top bar, `--primary-color` | —                          |
+| Empty state      | transparent                | `1px dashed --border-color` | `2px`  | none          | none                           | —                          |
+| Loading overlay  | `--card-bg-transparent-80` | —                           | —      | —             | —                              | —                          |
+
+## Motion
+
+| Token             | Value                                                           |
+| ----------------- | --------------------------------------------------------------- |
+| `--duration-fast` | `120ms`                                                         |
+| `--duration-base` | `160ms`                                                         |
+| `--ease`          | `cubic-bezier(0.4, 0, 0.2, 1)`                                  |
+| `--transition`    | `all var(--duration-base) var(--ease)`                          |
+| Hover             | Colour only — no lift                                           |
+| Press             | `translateY(1px)`                                               |
+| Reduced motion    | `@media (prefers-reduced-motion: reduce)` → all durations `0ms` |
+
+## Decorative layer
+
+Opt-in behind `[data-decor='on']` on `<html>`. Off by default.
+
+| Effect       | Token             | CSS                                                                                   | Default |
+| ------------ | ----------------- | ------------------------------------------------------------------------------------- | ------- |
+| Paper grain  | `--decor-overlay` | Tiled SVG `feTurbulence`, `opacity: .035`, `mix-blend-mode: overlay` on `body::after` | off     |
+| Section rule | `--decor-sheen`   | `linear-gradient(90deg, --primary-color, transparent)` on section `::before`          | off     |
+| Gradient     | —                 | _not used by this theme_                                                              | —       |
+| Glow         | —                 | _not used by this theme_                                                              | —       |
+
+## Token map
+
+Paste into `:root` in `src/assets/styles/_variables.css`.
+
+```css
+:root {
+  /* fonts */
+  --font-display: 'Shippori Mincho B1', Georgia, serif;
+  --font-body: 'Inter', system-ui, -apple-system, sans-serif;
+  --font-mono: 'IBM Plex Mono', ui-monospace, monospace;
+
+  /* type scale */
+  --text-xs: 0.694rem;
+  --text-sm: 0.833rem;
+  --text-base: 1rem;
+  --text-lg: 1.2rem;
+  --text-xl: 1.44rem;
+  --text-2xl: 1.728rem;
+  --text-3xl: 2.074rem;
+  --leading-tight: 1.25;
+  --leading-normal: 1.5;
+  --leading-relaxed: 1.7;
+  --tracking-normal: 0;
+  --tracking-wide: 0.02em;
+  --tracking-wider: 0.24em;
+  --weight-normal: 400;
+  --weight-medium: 500;
+  --weight-bold: 600;
+
+  /* surfaces */
+  --background-color: #15120e;
+  --card-color: #1e1a15;
+  --card-bg: var(--card-color);
+  --surface-raised: #262019;
+  --input-bg: #12100c;
+  --hover-bg: rgba(232, 163, 61, 0.08);
+  --border-color: #3a3025;
+  --border-strong: #7c6f5d;
+  --border-style: 1px solid var(--border-color);
+
+  /* content */
+  --text-color: #ede6d8;
+  --text-light: #a89b85;
+  --text-disabled: #7a6f60;
+  --button-text-color: #15120e;
+
+  /* brand */
+  --primary-color: #e8a33d;
+  --primary-dark: #c4832a;
+  --secondary-color: #5fa398;
+  --accent-color: #d4674a;
+
+  /* status */
+  --success-color: #6fa76b;
+  --success-text: #6fa76b;
+  --success-bg: rgba(111, 167, 107, 0.12);
+  --error-color: #e0655a;
+  --error-text: #e0655a;
+  --error-bg: rgba(224, 101, 90, 0.12);
+  --error-hover-color: #c24a40;
+  --disabled-color: #3a3025;
+
+  /* alpha */
+  --primary-transparent-10: rgba(232, 163, 61, 0.1);
+  --primary-transparent-15: rgba(232, 163, 61, 0.15);
+  --primary-transparent-20: rgba(232, 163, 61, 0.2);
+  --primary-transparent-30: rgba(232, 163, 61, 0.3);
+  --secondary-transparent-10: rgba(95, 163, 152, 0.1);
+  --secondary-transparent-50: rgba(95, 163, 152, 0.5);
+  --accent-transparent-10: rgba(212, 103, 74, 0.1);
+  --accent-transparent-50: rgba(212, 103, 74, 0.5);
+  --card-bg-transparent-30: rgba(30, 26, 21, 0.3);
+  --card-bg-transparent-50: rgba(30, 26, 21, 0.5);
+  --card-bg-transparent-80: rgba(30, 26, 21, 0.8);
+  --text-light-transparent-20: rgba(168, 155, 133, 0.2);
+  --text-light-transparent-30: rgba(168, 155, 133, 0.3);
+  --error-bg-transparent-10: rgba(224, 101, 90, 0.1);
+  --card-shadow: rgba(0, 0, 0, 0.45);
+  --spinner-bg: rgba(168, 155, 133, 0.15);
+
+  /* spacing */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+  --space-7: 48px;
+  --space-8: 64px;
+  --card-padding: var(--space-5);
+  --section-gap: var(--space-7);
+  --page-gutter: var(--space-6);
+  --content-max-width: 1100px;
+
+  /* shape & elevation */
+  --radius-sm: 2px;
+  --radius-md: 2px;
+  --border-radius: var(--radius-md);
+  --shadow-sm: none;
+  --shadow-md: 0 2px 6px var(--card-shadow);
+  --shadow-lg: 0 8px 28px var(--card-shadow);
+  --shadow: var(--shadow-md);
+  --focus-ring: 0 0 0 2px var(--primary-transparent-30);
+
+  /* motion */
+  --duration-fast: 120ms;
+  --duration-base: 160ms;
+  --ease: cubic-bezier(0.4, 0, 0.2, 1);
+  --transition: all var(--duration-base) var(--ease);
+
+  /* decoration (opt-in) */
+  --decor-overlay: none;
+  --decor-sheen: linear-gradient(90deg, var(--primary-color), transparent);
+}
+```
+
+## Preview
+
+```
+┌────────────────────────────────────────────────┐
+│▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔│ ← 2px #E8A33D
+│  リスト                                          │ ← kana micro-label, 11px
+│  Design Folks                                   │ ← Mincho 19.2px #EDE6D8
+│                                                 │
+│  42 members · updated 3d ago                    │ ← Plex Mono 13.3px #A89B85
+│                                                 │
+│  ┌───────────┐  ┌───────────┐                   │
+│  │   View    │  │  Curate   │                   │ ← amber fill / amber outline
+│  └───────────┘  └───────────┘                   │
+└────────────────────────────────────────────────┘
+   card #1E1A15 on page #15120E, 1px #3A3025, r2
+```
+
+Swatches — `#15120E` `#1E1A15` `#3A3025` `#7C6F5D` `#A89B85` `#EDE6D8` · `#E8A33D` `#C4832A`
+`#5FA398` `#D4674A` · `#6FA76B` `#E0655A`
+
+## Migration notes
+
+Beyond swapping the token block:
+
+- `app.css` — `body` must move from `--font-mono` to `--font-body`; add the `@font-face` or
+  preload links.
+- `data-card.css` — `--card-bg` and `--hover-bg` now resolve, so the modal and card action
+  hover states will render for the first time.
+- `action-buttons.css` — `.action-button` hard-codes `border-radius: 0`; switch to
+  `var(--radius-sm)`.
+- `dashboard.css`, `data-display.css` — hard-coded paddings should move to `--space-*`.
+- **No component markup changes required**, except adding the optional kana `<span>` to
+  section headers, which is additive.

--- a/docs/themes/theme-a-kissaten-light.md
+++ b/docs/themes/theme-a-kissaten-light.md
@@ -1,0 +1,279 @@
+# Theme A — Kissaten 喫茶店 · Light
+
+> **Mood:** aged paper and ink. A 1970s Japanese magazine spread or vinyl liner note, read in
+> daylight. Warm, quiet, literary.
+
+|           |                                                                                                                                                                                                                                                                                                                                                                              |
+| --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Family    | A — Kissaten (喫茶店, "coffee house")                                                                                                                                                                                                                                                                                                                                        |
+| Mode      | Light                                                                                                                                                                                                                                                                                                                                                                        |
+| Intensity | **Restrained / editorial** — lowest risk of the three                                                                                                                                                                                                                                                                                                                        |
+| Lineage   | Showa retro (昭和レトロ) — vinyl liner notes, 1970s Japanese print                                                                                                                                                                                                                                                                                                           |
+| Leans on  | [#2 flat geometry](../design/city-pop-aesthetics.md#2-flat-hard-edged-geometry), [#5 bilingual type](../design/city-pop-aesthetics.md#5-bilingual-typographic-pairing), [#6 horizon rules](../design/city-pop-aesthetics.md#6-horizon-lines-rules-and-perspective-grids), [#7 negative space](../design/city-pop-aesthetics.md#7-album-cover-composition-and-negative-space) |
+| Avoids    | Gradients, glow, chrome, scanlines                                                                                                                                                                                                                                                                                                                                           |
+
+## Typography
+
+Identical to the dark variant — typography does not change between modes.
+
+| Element                            | Value                                                                  |
+| ---------------------------------- | ---------------------------------------------------------------------- |
+| Display / headings                 | `Shippori Mincho B1` — serif, covers Latin + kana                      |
+| Body                               | `Inter`                                                                |
+| Data (handles, DIDs, counts, URIs) | `IBM Plex Mono`                                                        |
+| Fallback stack                     | `Georgia, serif` / `system-ui, sans-serif` / `ui-monospace, monospace` |
+| Weights loaded                     | Mincho 400/600 · Inter 400/500/600 · Plex Mono 400                     |
+| Delivery                           | Self-hosted WOFF2, `font-display: swap`, subset to Latin + kana used   |
+| Base size                          | `16px`                                                                 |
+| Scale ratio                        | **1.200** (minor third)                                                |
+| `--text-3xl`                       | `2.074rem` / 33px                                                      |
+| `--text-2xl`                       | `1.728rem` / 27.6px                                                    |
+| `--text-xl`                        | `1.440rem` / 23px                                                      |
+| `--text-lg`                        | `1.200rem` / 19.2px                                                    |
+| `--text-base`                      | `1rem` / 16px                                                          |
+| `--text-sm`                        | `0.833rem` / 13.3px                                                    |
+| `--text-xs`                        | `0.694rem` / 11.1px                                                    |
+| Line height                        | Headings `1.25` · body `1.7`                                           |
+| Tracking                           | Display `0.02em` · body `0` · kana label `0.24em`                      |
+| Casing                             | No uppercase transforms                                                |
+
+**Note.** Mincho's thin horizontal strokes are more fragile on light backgrounds than dark.
+Headings use weight `600` in light mode where dark mode can use `400`.
+
+## Colour
+
+Ratios measured against `--background-color` and `--card-color`; the lower is shown.
+
+### Surfaces
+
+| Token                        | Value                  | Role                      | Contrast | Verdict    |
+| ---------------------------- | ---------------------- | ------------------------- | -------- | ---------- |
+| `--background-color`         | `#F5EFE3`              | Page — aged paper         | —        | —          |
+| `--card-color` / `--card-bg` | `#FFFBF2`              | Card, panel — fresh paper | —        | —          |
+| `--surface-raised`           | `#FFFFFF`              | Modal, dropdown           | —        | —          |
+| `--input-bg`                 | `#FFFFFF`              | Field fill                | —        | —          |
+| `--hover-bg`                 | `rgba(138,84,22,0.06)` | Neutral hover wash        | —        | —          |
+| `--border-color`             | `#DDD2BE`              | Decorative separators     | 1.31     | decorative |
+| `--border-strong`            | `#8A7D66`              | Form-control borders      | **3.52** | ✅ AA      |
+
+### Content
+
+| Token                 | Value     | Role                       | Contrast  | Verdict |
+| --------------------- | --------- | -------------------------- | --------- | ------- |
+| `--text-color`        | `#211C15` | Body — warm near-black ink | **14.77** | ✅ AA   |
+| `--text-light`        | `#6B6155` | Metadata, handles          | **5.29**  | ✅ AA   |
+| `--text-disabled`     | `#877C6C` | Inactive                   | **3.57**  | ✅ (≥3) |
+| `--button-text-color` | `#FFFBF2` | On amber fill              | **5.79**  | ✅ AA   |
+
+### Brand roles
+
+The amber is pushed much deeper than the dark variant's `#E8A33D` — that value only reaches
+4.27:1 on paper, so it was darkened to `#8A5416` to clear AA for body-size text.
+
+| Token               | Value     | Role                          | Contrast | Verdict |
+| ------------------- | --------- | ----------------------------- | -------- | ------- |
+| `--primary-color`   | `#8A5416` | Deep amber — interactive      | **5.46** | ✅ AA   |
+| `--primary-dark`    | `#6B400F` | Pressed / hover fill          | **7.75** | ✅ AA   |
+| `--secondary-color` | `#2F6B62` | Deep teal — counterpoint      | **5.39** | ✅ AA   |
+| `--accent-color`    | `#9C3A22` | Persimmon 柿 — rare highlight | **6.03** | ✅ AA   |
+
+### Status
+
+| Token                                | Value     | Contrast | Verdict   |
+| ------------------------------------ | --------- | -------- | --------- |
+| `--success-color` / `--success-text` | `#2F6B3A` | **5.58** | ✅ AA     |
+| `--success-bg`                       | `#E4EFE2` | —        | —         |
+| `--error-color` / `--error-text`     | `#A32620` | **6.42** | ✅ AA     |
+| `--error-bg`                         | `#F7E4E2` | —        | —         |
+| `--error-hover-color`                | `#831C17` | —        | fill only |
+| `--disabled-color`                   | `#E5DCCB` | —        | —         |
+
+### Alpha variants
+
+| Token                                        | Value                                    |
+| -------------------------------------------- | ---------------------------------------- |
+| `--primary-transparent-10 / -15 / -20 / -30` | `rgba(138,84,22, .10 / .15 / .20 / .30)` |
+| `--secondary-transparent-10 / -50`           | `rgba(47,107,98, .10 / .50)`             |
+| `--accent-transparent-10 / -50`              | `rgba(156,58,34, .10 / .50)`             |
+| `--card-bg-transparent-30 / -50 / -80`       | `rgba(255,251,242, .30 / .50 / .80)`     |
+| `--text-light-transparent-20 / -30`          | `rgba(107,97,85, .20 / .30)`             |
+| `--error-bg-transparent-10`                  | `rgba(163,38,32,0.10)`                   |
+| `--card-shadow`                              | `rgba(60,45,25,0.12)`                    |
+| `--spinner-bg`                               | `rgba(107,97,85,0.15)`                   |
+
+## Buttons
+
+| Variant     | Fill                       | Border                | Text              | Radius | Padding     | Hover                                  | Active            | Focus                   |
+| ----------- | -------------------------- | --------------------- | ----------------- | ------ | ----------- | -------------------------------------- | ----------------- | ----------------------- |
+| Primary     | `--primary-color`          | none                  | `#FFFBF2`         | `2px`  | `10px 18px` | fill → `--primary-dark`                | `translateY(1px)` | `0 0 0 2px` @ 30% amber |
+| Secondary   | `--primary-transparent-10` | `1px --primary-color` | `--primary-color` | `2px`  | `10px 18px` | fill → 20%                             | `translateY(1px)` | same                    |
+| Ghost       | transparent                | `1px --border-strong` | `--text-color`    | `2px`  | `10px 18px` | fill → `--hover-bg`                    | `translateY(1px)` | same                    |
+| Destructive | `--error-color`            | none                  | `#FFFBF2`         | `2px`  | `10px 18px` | fill → `--error-hover-color`           | `translateY(1px)` | `0 0 0 2px` @ 30% red   |
+| Disabled    | `--disabled-color`         | none                  | `--text-disabled` | `2px`  | `10px 18px` | none                                   | none              | none                    |
+| Icon-only   | transparent                | none                  | `--text-light`    | `2px`  | `6px`       | `--hover-bg`, text → `--primary-color` | —                 | same                    |
+
+## Spacing & layout
+
+Identical to the dark variant — spacing does not change between modes.
+
+| Token                     | Value                                               |
+| ------------------------- | --------------------------------------------------- |
+| Base unit                 | `4px`                                               |
+| `--space-1` … `--space-8` | `4 · 8 · 12 · 16 · 24 · 32 · 48 · 64px`             |
+| `--card-padding`          | `--space-5` (24px)                                  |
+| `--section-gap`           | `--space-7` (48px)                                  |
+| `--page-gutter`           | `--space-6` (32px), `--space-4` (16px) below 1100px |
+| `--content-max-width`     | `1100px`                                            |
+| Card list gap             | `--space-3` (12px)                                  |
+| Breakpoints               | `1100px`, `720px`                                   |
+
+## Blocks & surfaces
+
+| Block            | Background                 | Border                      | Radius | Shadow        | Accent rule                    | Hover                      |
+| ---------------- | -------------------------- | --------------------------- | ------ | ------------- | ------------------------------ | -------------------------- |
+| Page             | `--background-color`       | —                           | —      | —             | —                              | —                          |
+| `DataCard`       | `--card-color`             | `1px --border-color`        | `2px`  | `--shadow-sm` | 2px top bar, `--primary-color` | border → `--primary-color` |
+| `MemberCard`     | `--card-color`             | `1px --border-color`        | `2px`  | none          | none                           | `--hover-bg`               |
+| Modal            | `--surface-raised`         | `1px --border-strong`       | `2px`  | `--shadow-lg` | none                           | —                          |
+| `AppHeader`      | `--card-color`             | bottom `1px --border-color` | —      | none          | none                           | —                          |
+| `ListChips` chip | `--primary-transparent-10` | `1px --primary-color`       | `2px`  | none          | none                           | fill → 20%                 |
+| `Pagination`     | transparent                | top `1px --border-color`    | —      | none          | none                           | —                          |
+| Form input       | `--input-bg`               | `1px --border-strong`       | `2px`  | none          | none                           | border → `--primary-color` |
+| `LoginForm`      | `--card-color`             | `1px --border-color`        | `2px`  | `--shadow-md` | 2px top bar, `--primary-color` | —                          |
+| Empty state      | transparent                | `1px dashed --border-color` | `2px`  | none          | none                           | —                          |
+| Loading overlay  | `--card-bg-transparent-80` | —                           | —      | —             | —                              | —                          |
+
+## Motion
+
+Identical to the dark variant.
+
+| Token             | Value                                                           |
+| ----------------- | --------------------------------------------------------------- |
+| `--duration-fast` | `120ms`                                                         |
+| `--duration-base` | `160ms`                                                         |
+| `--ease`          | `cubic-bezier(0.4, 0, 0.2, 1)`                                  |
+| `--transition`    | `all var(--duration-base) var(--ease)`                          |
+| Hover             | Colour only — no lift                                           |
+| Press             | `translateY(1px)`                                               |
+| Reduced motion    | `@media (prefers-reduced-motion: reduce)` → all durations `0ms` |
+
+## Decorative layer
+
+Opt-in behind `[data-decor='on']` on `<html>`. Off by default.
+
+| Effect       | Token             | CSS                                                                                   | Default |
+| ------------ | ----------------- | ------------------------------------------------------------------------------------- | ------- |
+| Paper grain  | `--decor-overlay` | Tiled SVG `feTurbulence`, `opacity: .05`, `mix-blend-mode: multiply` on `body::after` | off     |
+| Section rule | `--decor-sheen`   | `linear-gradient(90deg, --primary-color, transparent)` on section `::before`          | off     |
+| Gradient     | —                 | _not used by this theme_                                                              | —       |
+| Glow         | —                 | _not used by this theme_                                                              | —       |
+
+Grain is slightly stronger and uses `multiply` rather than `overlay` here — on paper it reads
+as print texture rather than noise.
+
+## Token map
+
+Paste into `.light-theme` in `src/assets/styles/_variables.css`.
+
+```css
+.light-theme {
+  /* surfaces */
+  --background-color: #f5efe3;
+  --card-color: #fffbf2;
+  --card-bg: var(--card-color);
+  --surface-raised: #ffffff;
+  --input-bg: #ffffff;
+  --hover-bg: rgba(138, 84, 22, 0.06);
+  --border-color: #ddd2be;
+  --border-strong: #8a7d66;
+  --border-style: 1px solid var(--border-color);
+
+  /* content */
+  --text-color: #211c15;
+  --text-light: #6b6155;
+  --text-disabled: #877c6c;
+  --button-text-color: #fffbf2;
+
+  /* brand */
+  --primary-color: #8a5416;
+  --primary-dark: #6b400f;
+  --secondary-color: #2f6b62;
+  --accent-color: #9c3a22;
+
+  /* status */
+  --success-color: #2f6b3a;
+  --success-text: #2f6b3a;
+  --success-bg: #e4efe2;
+  --error-color: #a32620;
+  --error-text: #a32620;
+  --error-bg: #f7e4e2;
+  --error-hover-color: #831c17;
+  --disabled-color: #e5dccb;
+
+  /* alpha */
+  --primary-transparent-10: rgba(138, 84, 22, 0.1);
+  --primary-transparent-15: rgba(138, 84, 22, 0.15);
+  --primary-transparent-20: rgba(138, 84, 22, 0.2);
+  --primary-transparent-30: rgba(138, 84, 22, 0.3);
+  --secondary-transparent-10: rgba(47, 107, 98, 0.1);
+  --secondary-transparent-50: rgba(47, 107, 98, 0.5);
+  --accent-transparent-10: rgba(156, 58, 34, 0.1);
+  --accent-transparent-50: rgba(156, 58, 34, 0.5);
+  --card-bg-transparent-30: rgba(255, 251, 242, 0.3);
+  --card-bg-transparent-50: rgba(255, 251, 242, 0.5);
+  --card-bg-transparent-80: rgba(255, 251, 242, 0.8);
+  --text-light-transparent-20: rgba(107, 97, 85, 0.2);
+  --text-light-transparent-30: rgba(107, 97, 85, 0.3);
+  --error-bg-transparent-10: rgba(163, 38, 32, 0.1);
+  --card-shadow: rgba(60, 45, 25, 0.12);
+  --spinner-bg: rgba(107, 97, 85, 0.15);
+
+  /* shape & elevation */
+  --shadow-sm: 0 1px 2px var(--card-shadow);
+  --shadow-md: 0 2px 6px var(--card-shadow);
+  --shadow-lg: 0 8px 28px var(--card-shadow);
+  --shadow: var(--shadow-md);
+  --focus-ring: 0 0 0 2px var(--primary-transparent-30);
+
+  /* decoration (opt-in) */
+  --decor-overlay: none;
+  --decor-sheen: linear-gradient(90deg, var(--primary-color), transparent);
+}
+```
+
+Font, type-scale, spacing, radius and motion tokens are inherited from `:root` — they are
+mode-independent and are not redeclared here.
+
+## Preview
+
+```
+┌────────────────────────────────────────────────┐
+│▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔│ ← 2px #8A5416
+│  リスト                                          │ ← kana micro-label, 11px
+│  Design Folks                                   │ ← Mincho 600 19.2px #211C15
+│                                                 │
+│  42 members · updated 3d ago                    │ ← Plex Mono 13.3px #6B6155
+│                                                 │
+│  ┌───────────┐  ┌───────────┐                   │
+│  │   View    │  │  Curate   │                   │ ← amber fill / amber outline
+│  └───────────┘  └───────────┘                   │
+└────────────────────────────────────────────────┘
+   card #FFFBF2 on page #F5EFE3, 1px #DDD2BE, r2
+```
+
+Swatches — `#F5EFE3` `#FFFBF2` `#DDD2BE` `#8A7D66` `#6B6155` `#211C15` · `#8A5416` `#6B400F`
+`#2F6B62` `#9C3A22` · `#2F6B3A` `#A32620`
+
+## Migration notes
+
+Beyond swapping the token block:
+
+- `app.css` — `body` must move from `--font-mono` to `--font-body`; heading rules need
+  `font-weight: 600` in light mode (mincho hairlines thin out on paper).
+- `data-card.css` — `--card-bg` and `--hover-bg` now resolve, so the modal and card action
+  hover states will render for the first time.
+- `list-form.css` — `--input-bg` now resolves; inputs get a white fill against the paper page,
+  which is what the existing rule always intended.
+- `action-buttons.css` — `.action-button` hard-codes `border-radius: 0`; switch to
+  `var(--radius-sm)`.
+- **No component markup changes required**, except the optional kana `<span>`.

--- a/docs/themes/theme-a-kissaten.html
+++ b/docs/themes/theme-a-kissaten.html
@@ -1,0 +1,895 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Theme A — Kissaten 喫茶店 · Bluelist</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono&family=Inter:wght@400;500;600&family=Shippori+Mincho+B1:wght@400;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* ─── THEME TOKENS — dark (:root) ─────────────────────────────── */
+      :root {
+        --font-display: 'Shippori Mincho B1', Georgia, serif;
+        --font-body: 'Inter', system-ui, -apple-system, sans-serif;
+        --font-mono: 'IBM Plex Mono', ui-monospace, monospace;
+        --font-kana: var(--font-display);
+
+        --text-xs: 0.694rem;
+        --text-sm: 0.833rem;
+        --text-base: 1rem;
+        --text-lg: 1.2rem;
+        --text-xl: 1.44rem;
+        --text-2xl: 1.728rem;
+        --text-3xl: 2.074rem;
+        --leading-tight: 1.25;
+        --leading-relaxed: 1.7;
+        --tracking-wide: 0.02em;
+        --tracking-wider: 0.24em;
+        --weight-bold: 600;
+
+        --background-color: #15120e;
+        --card-color: #1e1a15;
+        --card-bg: var(--card-color);
+        --surface-raised: #262019;
+        --input-bg: #12100c;
+        --hover-bg: rgba(232, 163, 61, 0.08);
+        --border-color: #3a3025;
+        --border-strong: #7c6f5d;
+        --border-style: 1px solid var(--border-color);
+
+        --text-color: #ede6d8;
+        --text-light: #a89b85;
+        --text-disabled: #7a6f60;
+        --button-text-color: #15120e;
+
+        --primary-color: #e8a33d;
+        --primary-dark: #c4832a;
+        --secondary-color: #5fa398;
+        --accent-color: #d4674a;
+
+        --success-color: #6fa76b;
+        --success-text: #6fa76b;
+        --success-bg: rgba(111, 167, 107, 0.12);
+        --error-color: #e0655a;
+        --error-text: #e0655a;
+        --error-bg: rgba(224, 101, 90, 0.12);
+        --error-hover-color: #c24a40;
+        --disabled-color: #3a3025;
+
+        --primary-transparent-10: rgba(232, 163, 61, 0.1);
+        --primary-transparent-20: rgba(232, 163, 61, 0.2);
+        --primary-transparent-30: rgba(232, 163, 61, 0.3);
+        --card-bg-transparent-80: rgba(30, 26, 21, 0.8);
+        --card-shadow: rgba(0, 0, 0, 0.45);
+        --spinner-bg: rgba(168, 155, 133, 0.15);
+
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 24px;
+        --space-6: 32px;
+        --space-7: 48px;
+        --space-8: 64px;
+        --card-padding: var(--space-5);
+        --content-max-width: 1100px;
+
+        --radius-sm: 2px;
+        --radius-md: 2px;
+        --shadow-sm: none;
+        --shadow-md: 0 2px 6px var(--card-shadow);
+        --shadow-lg: 0 8px 28px var(--card-shadow);
+        --focus-ring: 0 0 0 2px var(--primary-transparent-30);
+
+        --duration-base: 160ms;
+        --ease: cubic-bezier(0.4, 0, 0.2, 1);
+        --transition: all var(--duration-base) var(--ease);
+
+        --decor-overlay: none;
+        --grain-blend: overlay;
+        --grain-opacity: 0.035;
+      }
+
+      /* ─── THEME TOKENS — light ────────────────────────────────────── */
+      .light-theme {
+        --background-color: #f5efe3;
+        --card-color: #fffbf2;
+        --surface-raised: #ffffff;
+        --input-bg: #ffffff;
+        --hover-bg: rgba(138, 84, 22, 0.06);
+        --border-color: #ddd2be;
+        --border-strong: #8a7d66;
+
+        --text-color: #211c15;
+        --text-light: #6b6155;
+        --text-disabled: #877c6c;
+        --button-text-color: #fffbf2;
+
+        --primary-color: #8a5416;
+        --primary-dark: #6b400f;
+        --secondary-color: #2f6b62;
+        --accent-color: #9c3a22;
+
+        --success-color: #2f6b3a;
+        --success-text: #2f6b3a;
+        --success-bg: #e4efe2;
+        --error-color: #a32620;
+        --error-text: #a32620;
+        --error-bg: #f7e4e2;
+        --error-hover-color: #831c17;
+        --disabled-color: #e5dccb;
+
+        --primary-transparent-10: rgba(138, 84, 22, 0.1);
+        --primary-transparent-20: rgba(138, 84, 22, 0.2);
+        --primary-transparent-30: rgba(138, 84, 22, 0.3);
+        --card-bg-transparent-80: rgba(255, 251, 242, 0.8);
+        --card-shadow: rgba(60, 45, 25, 0.12);
+        --spinner-bg: rgba(107, 97, 85, 0.15);
+
+        --shadow-sm: 0 1px 2px var(--card-shadow);
+        --grain-blend: multiply;
+        --grain-opacity: 0.05;
+      }
+      .light-theme .u-heading {
+        font-weight: 600;
+      }
+
+      /* ─── PREVIEW CHROME ──────────────────────────────────────────── */
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family: var(--font-body);
+        background: var(--background-color);
+        color: var(--text-color);
+        line-height: var(--leading-relaxed);
+        transition: background-color var(--duration-base) var(--ease),
+          color var(--duration-base) var(--ease);
+      }
+      html[data-decor='on'] body::after {
+        content: '';
+        position: fixed;
+        inset: 0;
+        pointer-events: none;
+        z-index: 9998;
+        opacity: var(--grain-opacity);
+        mix-blend-mode: var(--grain-blend);
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.8' numOctaves='4'/%3E%3C/filter%3E%3Crect width='200' height='200' filter='url(%23n)'/%3E%3C/svg%3E");
+      }
+
+      .wrap {
+        max-width: var(--content-max-width);
+        margin: 0 auto;
+        padding: var(--space-6);
+      }
+      .bar {
+        position: sticky;
+        top: 0;
+        z-index: 9999;
+        display: flex;
+        gap: var(--space-3);
+        align-items: center;
+        flex-wrap: wrap;
+        padding: var(--space-3) var(--space-6);
+        background: var(--card-color);
+        border-bottom: var(--border-style);
+      }
+      .bar__title {
+        font-family: var(--font-display);
+        font-size: var(--text-lg);
+        color: var(--primary-color);
+        margin-right: auto;
+      }
+      .bar__tag {
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        color: var(--text-light);
+        border: 1px solid var(--border-color);
+        padding: 2px 8px;
+      }
+
+      h2.sec {
+        font-family: var(--font-display);
+        font-size: var(--text-2xl);
+        line-height: var(--leading-tight);
+        margin: var(--space-8) 0 var(--space-2);
+        letter-spacing: var(--tracking-wide);
+      }
+      h2.sec:first-of-type {
+        margin-top: var(--space-5);
+      }
+      .kana {
+        font-family: var(--font-kana);
+        font-size: var(--text-xs);
+        letter-spacing: var(--tracking-wider);
+        color: var(--text-light);
+        text-transform: none;
+        display: block;
+      }
+      .lede {
+        color: var(--text-light);
+        max-width: 62ch;
+        margin-bottom: var(--space-5);
+      }
+      .rule {
+        height: 2px;
+        background: var(--primary-color);
+        margin-bottom: var(--space-5);
+      }
+
+      /* swatches */
+      .sw-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
+        gap: var(--space-3);
+      }
+      .sw {
+        border: var(--border-style);
+        border-radius: var(--radius-sm);
+        overflow: hidden;
+      }
+      .sw__chip {
+        height: 76px;
+      }
+      .sw__meta {
+        padding: var(--space-2) var(--space-3);
+        background: var(--card-color);
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        line-height: 1.8;
+      }
+      .sw__name {
+        color: var(--text-color);
+      }
+      .sw__hex {
+        color: var(--text-light);
+        text-transform: uppercase;
+      }
+      .sw__ratio {
+        color: var(--success-text);
+      }
+
+      /* type specimen */
+      .spec > * {
+        margin-bottom: var(--space-3);
+      }
+      .spec .s3 {
+        font-family: var(--font-display);
+        font-size: var(--text-3xl);
+        line-height: var(--leading-tight);
+        letter-spacing: var(--tracking-wide);
+      }
+      .spec .s2 {
+        font-family: var(--font-display);
+        font-size: var(--text-2xl);
+        line-height: var(--leading-tight);
+      }
+      .spec .s1 {
+        font-family: var(--font-display);
+        font-size: var(--text-xl);
+        line-height: var(--leading-tight);
+      }
+      .spec .s0 {
+        font-family: var(--font-display);
+        font-size: var(--text-lg);
+      }
+      .spec .body {
+        font-size: var(--text-base);
+        max-width: 62ch;
+      }
+      .spec .meta {
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        color: var(--text-light);
+      }
+
+      /* buttons */
+      .btn-row {
+        display: flex;
+        gap: var(--space-3);
+        flex-wrap: wrap;
+        align-items: center;
+      }
+      .btn {
+        font-family: var(--font-body);
+        font-size: 0.95rem;
+        font-weight: 500;
+        border: none;
+        border-radius: var(--radius-sm);
+        padding: 10px 18px;
+        cursor: pointer;
+        transition: var(--transition);
+      }
+      .btn:active {
+        transform: translateY(1px);
+      }
+      .btn:focus-visible {
+        outline: none;
+        box-shadow: var(--focus-ring);
+      }
+      .btn--primary {
+        background: var(--primary-color);
+        color: var(--button-text-color);
+      }
+      .btn--primary:hover {
+        background: var(--primary-dark);
+      }
+      .btn--secondary {
+        background: var(--primary-transparent-10);
+        border: 1px solid var(--primary-color);
+        color: var(--primary-color);
+      }
+      .btn--secondary:hover {
+        background: var(--primary-transparent-20);
+      }
+      .btn--ghost {
+        background: transparent;
+        border: 1px solid var(--border-strong);
+        color: var(--text-color);
+      }
+      .btn--ghost:hover {
+        background: var(--hover-bg);
+      }
+      .btn--danger {
+        background: var(--error-color);
+        color: var(--button-text-color);
+      }
+      .btn--danger:hover {
+        background: var(--error-hover-color);
+      }
+      .btn--disabled {
+        background: var(--disabled-color);
+        color: var(--text-disabled);
+        cursor: not-allowed;
+      }
+      .btn--icon {
+        background: transparent;
+        color: var(--text-light);
+        padding: 6px;
+        font-size: 1.1rem;
+        line-height: 1;
+      }
+      .btn--icon:hover {
+        background: var(--hover-bg);
+        color: var(--primary-color);
+      }
+
+      /* app mock */
+      .mock {
+        border: var(--border-style);
+        border-radius: var(--radius-sm);
+        overflow: hidden;
+      }
+      .mock__header {
+        display: flex;
+        align-items: center;
+        gap: var(--space-3);
+        padding: var(--space-4) var(--space-5);
+        background: var(--background-color);
+        border-bottom: var(--border-style);
+      }
+      .mock__logo {
+        font-family: var(--font-display);
+        font-size: var(--text-xl);
+        color: var(--primary-color);
+        letter-spacing: var(--tracking-wide);
+        margin-right: auto;
+      }
+      .mock__status {
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        color: var(--text-light);
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .dot {
+        width: 8px;
+        height: 8px;
+        background: var(--success-color);
+        border-radius: 50%;
+      }
+      .mock__body {
+        padding: var(--space-5);
+        background: var(--background-color);
+        display: grid;
+        grid-template-columns: 220px 1fr;
+        gap: var(--space-5);
+      }
+      @media (max-width: 820px) {
+        .mock__body {
+          grid-template-columns: 1fr;
+        }
+      }
+      .panel {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+      }
+
+      .card {
+        background: var(--card-color);
+        border: var(--border-style);
+        border-radius: var(--radius-sm);
+        box-shadow: var(--shadow-sm);
+        padding: var(--card-padding);
+        margin-bottom: var(--space-3);
+        position: relative;
+        transition: var(--transition);
+      }
+      .card::before {
+        content: '';
+        position: absolute;
+        inset: 0 0 auto 0;
+        height: 2px;
+        background: var(--primary-color);
+      }
+      .card:hover {
+        border-color: var(--primary-color);
+      }
+      .card__title {
+        font-family: var(--font-display);
+        font-size: var(--text-lg);
+        line-height: var(--leading-tight);
+      }
+      .card__meta {
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        color: var(--text-light);
+        margin: var(--space-1) 0 var(--space-4);
+      }
+
+      .member {
+        display: flex;
+        align-items: center;
+        gap: var(--space-3);
+        background: var(--card-color);
+        border: var(--border-style);
+        border-radius: var(--radius-sm);
+        padding: var(--space-3) var(--space-4);
+        margin-bottom: 6px;
+        transition: var(--transition);
+      }
+      .member:hover {
+        background: var(--hover-bg);
+      }
+      .avatar {
+        width: 34px;
+        height: 34px;
+        border-radius: 50%;
+        background: var(--primary-transparent-20);
+        border: 1px solid var(--primary-color);
+        flex: none;
+      }
+      .member__name {
+        font-weight: 500;
+      }
+      .member__handle {
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        color: var(--text-light);
+      }
+
+      .chips {
+        display: flex;
+        gap: var(--space-2);
+        flex-wrap: wrap;
+        margin-top: var(--space-3);
+      }
+      .chip {
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        background: var(--primary-transparent-10);
+        border: 1px solid var(--primary-color);
+        border-radius: var(--radius-sm);
+        color: var(--primary-color);
+        padding: 4px 10px;
+        cursor: pointer;
+        transition: var(--transition);
+      }
+      .chip:hover {
+        background: var(--primary-transparent-20);
+      }
+      .chip--off {
+        background: var(--disabled-color);
+        border-color: var(--disabled-color);
+        color: var(--text-disabled);
+      }
+
+      .pager {
+        display: flex;
+        align-items: center;
+        gap: var(--space-3);
+        border-top: var(--border-style);
+        padding-top: var(--space-3);
+        margin-top: var(--space-4);
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        color: var(--text-light);
+      }
+      .pager button {
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        background: var(--primary-transparent-10);
+        border: 1px solid var(--primary-color);
+        color: var(--primary-color);
+        border-radius: var(--radius-sm);
+        padding: 4px 12px;
+        cursor: pointer;
+      }
+
+      .field {
+        display: block;
+        margin-bottom: var(--space-3);
+      }
+      .field label {
+        display: block;
+        font-size: var(--text-sm);
+        color: var(--text-light);
+        margin-bottom: 6px;
+      }
+      .field input {
+        width: 100%;
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        background: var(--input-bg);
+        border: 1px solid var(--border-strong);
+        border-radius: var(--radius-sm);
+        color: var(--text-color);
+        padding: 10px 12px;
+        transition: var(--transition);
+      }
+      .field input:focus {
+        outline: none;
+        border-color: var(--primary-color);
+        box-shadow: var(--focus-ring);
+      }
+
+      .note {
+        border-radius: var(--radius-sm);
+        padding: var(--space-3) var(--space-4);
+        margin-bottom: var(--space-3);
+        font-size: var(--text-sm);
+      }
+      .note--ok {
+        background: var(--success-bg);
+        color: var(--success-text);
+        border-left: 3px solid var(--success-text);
+      }
+      .note--err {
+        background: var(--error-bg);
+        color: var(--error-text);
+        border-left: 3px solid var(--error-text);
+      }
+
+      .empty {
+        border: 1px dashed var(--border-color);
+        border-radius: var(--radius-sm);
+        padding: var(--space-6);
+        text-align: center;
+        color: var(--text-light);
+      }
+
+      .cols {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-5);
+      }
+      @media (max-width: 820px) {
+        .cols {
+          grid-template-columns: 1fr;
+        }
+      }
+
+      .scale-row {
+        display: flex;
+        align-items: center;
+        gap: var(--space-3);
+        margin-bottom: 6px;
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        color: var(--text-light);
+      }
+      .scale-bar {
+        height: 14px;
+        background: var(--primary-transparent-30);
+        border-left: 2px solid var(--primary-color);
+      }
+
+      table.tk {
+        width: 100%;
+        border-collapse: collapse;
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+      }
+      table.tk th,
+      table.tk td {
+        text-align: left;
+        padding: 8px 10px;
+        border-bottom: var(--border-style);
+      }
+      table.tk th {
+        color: var(--text-light);
+        font-weight: 400;
+      }
+      .ok {
+        color: var(--success-text);
+      }
+
+      footer.f {
+        margin-top: var(--space-8);
+        padding-top: var(--space-5);
+        border-top: var(--border-style);
+        color: var(--text-light);
+        font-size: var(--text-sm);
+      }
+      footer.f a {
+        color: var(--primary-color);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="bar">
+      <div class="bar__title">Theme A — Kissaten 喫茶店</div>
+      <span class="bar__tag">restrained / editorial</span>
+      <button class="btn btn--secondary" id="mode">◐ Light mode</button>
+      <button class="btn btn--ghost" id="decor">Decoration: off</button>
+    </div>
+
+    <div class="wrap">
+      <h2 class="sec"><span class="kana">きっさてん</span>Overview</h2>
+      <div class="rule"></div>
+      <p class="lede">
+        A 1970s Tokyo coffee shop. Warm charcoal and amber lamplight in the
+        dark; aged paper and ink in the light. Quiet, literary, unhurried — the
+        Showa-retro register of city pop rather than the poolside or neon ones.
+        Lowest risk of the three families, and the closest to a document.
+      </p>
+
+      <h2 class="sec"><span class="kana">いろ</span>Palette</h2>
+      <div class="rule"></div>
+      <p class="lede">
+        Every value is checked against both the page and the card background;
+        the figure shown is the lower of the two.
+      </p>
+      <div class="sw-grid" id="swatches"></div>
+
+      <h2 class="sec"><span class="kana">もじ</span>Typography</h2>
+      <div class="rule"></div>
+      <p class="lede">
+        Shippori Mincho B1 for headings, Inter for body, IBM Plex Mono for data.
+        Scale ratio 1.200 — gentle and editorial. Mono is reserved for handles,
+        DIDs, counts and URIs.
+      </p>
+      <div class="spec">
+        <div class="s3 u-heading">Organise your follows</div>
+        <div class="s2 u-heading">Design Folks</div>
+        <div class="s1 u-heading">42 members</div>
+        <div class="s0 u-heading">Suggested lists</div>
+        <p class="body">
+          Body copy is set in Inter at 16px with a 1.7 line height — generous,
+          print-like leading that suits the long member lists this app is mostly
+          made of. The serif stays in the headings, where its thin horizontals
+          are safe.
+        </p>
+        <div class="meta">@samuel.bsky.social · did:plc:7f3k… · 3d ago</div>
+      </div>
+
+      <h2 class="sec"><span class="kana">ボタン</span>Buttons</h2>
+      <div class="rule"></div>
+      <p class="lede">
+        Hover and focus each one — 2px radius, flat fills, no gradients.
+      </p>
+      <div class="btn-row">
+        <button class="btn btn--primary">View list</button>
+        <button class="btn btn--secondary">Curate with AI</button>
+        <button class="btn btn--ghost">Cancel</button>
+        <button class="btn btn--danger">Delete list</button>
+        <button class="btn btn--disabled" disabled>Unavailable</button>
+        <button class="btn btn--icon" title="Edit">✎</button>
+        <button class="btn btn--icon" title="Delete">🗑</button>
+      </div>
+
+      <h2 class="sec"><span class="kana">がめん</span>Interface</h2>
+      <div class="rule"></div>
+      <p class="lede">
+        The real Bluelist surfaces — header, action panel, cards, member rows,
+        chips and pagination.
+      </p>
+      <div class="mock">
+        <div class="mock__header">
+          <div class="mock__logo">bluelist</div>
+          <div class="mock__status">
+            <span class="dot"></span>@samuel.bsky.social
+          </div>
+          <button class="btn btn--icon" title="Toggle theme">☾</button>
+        </div>
+        <div class="mock__body">
+          <div class="panel">
+            <button class="btn btn--secondary">Get timeline</button>
+            <button class="btn btn--secondary">Get follows</button>
+            <button class="btn btn--secondary">Get lists</button>
+            <button class="btn btn--primary">Curate</button>
+          </div>
+          <div>
+            <div class="card">
+              <div class="card__title">Design Folks</div>
+              <div class="card__meta">42 members · updated 3d ago</div>
+              <div class="member">
+                <div class="avatar"></div>
+                <div>
+                  <div class="member__name">Mariya Takeuchi</div>
+                  <div class="member__handle">@mariya.bsky.social</div>
+                </div>
+              </div>
+              <div class="member">
+                <div class="avatar"></div>
+                <div>
+                  <div class="member__name">Tatsuro Yamashita</div>
+                  <div class="member__handle">@tatsuro.bsky.social</div>
+                </div>
+              </div>
+              <div class="chips">
+                <span class="chip">Design Folks</span>
+                <span class="chip">Music</span>
+                <span class="chip chip--off">Archived</span>
+              </div>
+              <div class="pager">
+                <button>‹ Prev</button>
+                <span>Page 2 of 7</span>
+                <button>Next ›</button>
+              </div>
+            </div>
+            <div class="note note--ok">Added 3 users to “Design Folks”.</div>
+            <div class="note note--err">
+              Token has expired — please sign in again.
+            </div>
+            <div class="empty">No lists yet. Create one to get started.</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="cols">
+        <div>
+          <h2 class="sec"><span class="kana">フォーム</span>Form</h2>
+          <div class="rule"></div>
+          <label class="field">
+            <label>List name</label>
+            <input value="Design Folks" />
+          </label>
+          <label class="field">
+            <label>Description</label>
+            <input placeholder="Focus this input to see the ring" />
+          </label>
+          <div class="btn-row">
+            <button class="btn btn--primary">Save</button>
+            <button class="btn btn--ghost">Cancel</button>
+          </div>
+        </div>
+        <div>
+          <h2 class="sec"><span class="kana">よはく</span>Spacing</h2>
+          <div class="rule"></div>
+          <div id="scale"></div>
+          <p class="lede" style="margin-top: var(--space-4)">
+            4px base unit. Card padding 24px, section gap 48px, content width
+            1100px — narrower than today's 1200px.
+          </p>
+        </div>
+      </div>
+
+      <h2 class="sec"><span class="kana">コントラスト</span>Contrast record</h2>
+      <div class="rule"></div>
+      <table class="tk" id="contrast"></table>
+
+      <footer class="f">
+        Full specification:
+        <a href="theme-a-kissaten-dark.md">dark</a> ·
+        <a href="theme-a-kissaten-light.md">light</a> ·
+        <a href="index.html">compare all three families</a><br />
+        Fonts load from Google Fonts in this preview only; production is
+        self-hosted WOFF2, subset, <code>font-display: swap</code>.
+      </footer>
+    </div>
+
+    <script>
+      const SW = {
+        dark: [
+          ['--background-color', '#15120E', 'page', ''],
+          ['--card-color', '#1E1A15', 'card', ''],
+          ['--surface-raised', '#262019', 'modal', ''],
+          ['--border-color', '#3A3025', 'separator', ''],
+          ['--border-strong', '#7C6F5D', 'control border', '3.53'],
+          ['--text-disabled', '#7A6F60', 'inactive', '3.52'],
+          ['--text-light', '#A89B85', 'metadata', '6.34'],
+          ['--text-color', '#EDE6D8', 'body', '13.93'],
+          ['--primary-color', '#E8A33D', 'amber · interactive', '8.02'],
+          ['--primary-dark', '#C4832A', 'pressed', '5.46'],
+          ['--secondary-color', '#5FA398', 'teal · counterpoint', '5.91'],
+          ['--accent-color', '#D4674A', 'persimmon · highlight', '4.81'],
+          ['--success-color', '#6FA76B', 'success', '6.11'],
+          ['--error-color', '#E0655A', 'error', '5.09'],
+        ],
+        light: [
+          ['--background-color', '#F5EFE3', 'page', ''],
+          ['--card-color', '#FFFBF2', 'card', ''],
+          ['--surface-raised', '#FFFFFF', 'modal', ''],
+          ['--border-color', '#DDD2BE', 'separator', ''],
+          ['--border-strong', '#8A7D66', 'control border', '3.52'],
+          ['--text-disabled', '#877C6C', 'inactive', '3.57'],
+          ['--text-light', '#6B6155', 'metadata', '5.29'],
+          ['--text-color', '#211C15', 'body', '14.77'],
+          ['--primary-color', '#8A5416', 'amber · interactive', '5.46'],
+          ['--primary-dark', '#6B400F', 'pressed', '7.75'],
+          ['--secondary-color', '#2F6B62', 'teal · counterpoint', '5.39'],
+          ['--accent-color', '#9C3A22', 'persimmon · highlight', '6.03'],
+          ['--success-color', '#2F6B3A', 'success', '5.58'],
+          ['--error-color', '#A32620', 'error', '6.42'],
+        ],
+      };
+
+      const root = document.documentElement;
+      const isLight = () => root.classList.contains('light-theme');
+
+      function render() {
+        const rows = isLight() ? SW.light : SW.dark;
+        document.getElementById('swatches').innerHTML = rows
+          .map(
+            ([t, hex, role, ratio]) => `
+        <div class="sw">
+          <div class="sw__chip" style="background:${hex}"></div>
+          <div class="sw__meta">
+            <div class="sw__name">${role}</div>
+            <div class="sw__hex">${hex}</div>
+            <div class="sw__ratio">${ratio ? ratio + ':1 ✓' : '&nbsp;'}</div>
+          </div>
+        </div>`
+          )
+          .join('');
+
+        document.getElementById('contrast').innerHTML =
+          '<tr><th>Token</th><th>Value</th><th>Role</th><th>Ratio</th></tr>' +
+          rows
+            .map(
+              ([t, hex, role, ratio]) =>
+                `<tr><td>${t}</td><td>${hex}</td><td>${role}</td><td class="ok">${
+                  ratio ? ratio + ':1' : '—'
+                }</td></tr>`
+            )
+            .join('');
+      }
+
+      document.getElementById('scale').innerHTML = [
+        4, 8, 12, 16, 24, 32, 48, 64,
+      ]
+        .map(
+          (v, i) =>
+            `<div class="scale-row"><span style="width:70px">--space-${
+              i + 1
+            }</span><div class="scale-bar" style="width:${
+              v * 2
+            }px"></div><span>${v}px</span></div>`
+        )
+        .join('');
+
+      document.getElementById('mode').onclick = (e) => {
+        root.classList.toggle('light-theme');
+        e.target.textContent = isLight() ? '◑ Dark mode' : '◐ Light mode';
+        render();
+      };
+      document.getElementById('decor').onclick = (e) => {
+        const on = root.getAttribute('data-decor') === 'on';
+        root.setAttribute('data-decor', on ? 'off' : 'on');
+        e.target.textContent =
+          'Decoration: ' + (on ? 'off' : 'on (paper grain)');
+      };
+
+      render();
+    </script>
+  </body>
+</html>

--- a/docs/themes/theme-b-poolside-dark.md
+++ b/docs/themes/theme-b-poolside-dark.md
@@ -1,0 +1,331 @@
+# Theme B — Poolside プールサイド · Dark
+
+> **Mood:** Hiroshi Nagai's pool at dusk. Deep sky navy, lit water, a coral sun going down.
+> Bright and optimistic without being loud.
+
+|           |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Family    | B — Poolside (プールサイド)                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| Mode      | Dark                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| Intensity | **Balanced** — the default recommendation                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| Lineage   | Nagai / Ohtaki / resort AOR — the daytime lineage, after sundown                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| Leans on  | [#1 gradient skies](../design/city-pop-aesthetics.md#1-gradient-skies-and-time-of-day-light), [#2 flat geometry](../design/city-pop-aesthetics.md#2-flat-hard-edged-geometry), [#3 tropical accents](../design/city-pop-aesthetics.md#3-high-chroma-tropical-accents-on-a-cool-base), [#4 chrome & water](../design/city-pop-aesthetics.md#4-chrome-glass-and-water-reflection), [#6 horizon rules](../design/city-pop-aesthetics.md#6-horizon-lines-rules-and-perspective-grids) |
+| Avoids    | Scanlines, glitch, neon glow                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+
+## Typography
+
+Geometric sans with wide tracking on headings — the sleeve-lettering register, without the
+commitment of a serif.
+
+| Element                            | Value                                                                      |
+| ---------------------------------- | -------------------------------------------------------------------------- |
+| Display / headings                 | `Outfit` — geometric sans, Latin                                           |
+| Body                               | `Inter`                                                                    |
+| Data (handles, DIDs, counts, URIs) | `IBM Plex Mono`                                                            |
+| Fallback stack                     | `system-ui, sans-serif` throughout                                         |
+| Weights loaded                     | Outfit 500/700 · Inter 400/500/600 · Plex Mono 400                         |
+| Delivery                           | `@nuxt/fonts` — self-hosted, subset, `font-display: swap`                  |
+| Base size                          | `16px`                                                                     |
+| Scale ratio                        | **1.250** (major third) — more contrast than A, less than C                |
+| `--text-3xl`                       | `2.441rem` / 39px — page title                                             |
+| `--text-2xl`                       | `1.953rem` / 31.2px — h2                                                   |
+| `--text-xl`                        | `1.563rem` / 25px — h3                                                     |
+| `--text-lg`                        | `1.250rem` / 20px — h4, card title                                         |
+| `--text-base`                      | `1rem` / 16px — body                                                       |
+| `--text-sm`                        | `0.800rem` / 12.8px — metadata                                             |
+| `--text-xs`                        | `0.640rem` / 10.2px — fine print                                           |
+| Line height                        | Headings `1.2` · body `1.6`                                                |
+| Tracking                           | Display `0.06em` · body `0`                                                |
+| Casing                             | Display headings `uppercase` at `--text-lg` and below; sentence case above |
+
+**Latin only.** Japanese micro-labels were considered and dropped — the aesthetic is
+carried by colour, type and layout without them.
+
+## Colour
+
+Ratios measured against `--background-color` and `--card-color`; the lower is shown.
+Target ≥ 4.5:1 for text and brand roles, ≥ 3:1 for disabled text and control borders.
+
+### Surfaces
+
+| Token                        | Value                   | Role                  | Contrast | Verdict    |
+| ---------------------------- | ----------------------- | --------------------- | -------- | ---------- |
+| `--background-color`         | `#0E1B2A`               | Page — deep dusk navy | —        | —          |
+| `--card-color` / `--card-bg` | `#16283C`               | Card, panel           | —        | —          |
+| `--surface-raised`           | `#1E344C`               | Modal, dropdown       | —        | —          |
+| `--input-bg`                 | `#0A1522`               | Field fill — recessed | —        | —          |
+| `--hover-bg`                 | `rgba(69,208,224,0.08)` | Neutral hover wash    | —        | —          |
+| `--border-color`             | `#2A4767`               | Decorative separators | 1.82     | decorative |
+| `--border-strong`            | `#5F7C99`               | Form-control borders  | **3.44** | ✅ AA      |
+
+### Content
+
+| Token                 | Value     | Role                  | Contrast  | Verdict |
+| --------------------- | --------- | --------------------- | --------- | ------- |
+| `--text-color`        | `#E6F1F7` | Body — cool off-white | **13.04** | ✅ AA   |
+| `--text-light`        | `#93AFC6` | Metadata, handles     | **6.55**  | ✅ AA   |
+| `--text-disabled`     | `#6D8AA1` | Inactive              | **4.13**  | ✅ (≥3) |
+| `--button-text-color` | `#0E1B2A` | On aqua fill          | **8.09**  | ✅ AA   |
+
+### Brand roles
+
+The clearest expression of [characteristic 3](../design/city-pop-aesthetics.md#3-high-chroma-tropical-accents-on-a-cool-base):
+cool primary, warm secondary, high-attention tertiary.
+
+| Token               | Value     | Role                        | Contrast  | Verdict |
+| ------------------- | --------- | --------------------------- | --------- | ------- |
+| `--primary-color`   | `#45D0E0` | Pool aqua — interactive     | **8.09**  | ✅ AA   |
+| `--primary-dark`    | `#2AA7B6` | Pressed / hover fill        | **5.20**  | ✅ AA   |
+| `--secondary-color` | `#FF8A6B` | Coral sunset — counterpoint | **6.49**  | ✅ AA   |
+| `--accent-color`    | `#FFD166` | Sun yellow — rare highlight | **10.38** | ✅ AA   |
+
+### Status
+
+| Token                                | Value                    | Contrast | Verdict   |
+| ------------------------------------ | ------------------------ | -------- | --------- |
+| `--success-color` / `--success-text` | `#4FD1A0`                | **7.81** | ✅ AA     |
+| `--success-bg`                       | `rgba(79,209,160,0.12)`  | —        | —         |
+| `--error-color` / `--error-text`     | `#FF6B6B`                | **5.39** | ✅ AA     |
+| `--error-bg`                         | `rgba(255,107,107,0.12)` | —        | —         |
+| `--error-hover-color`                | `#E04E4E`                | —        | fill only |
+| `--disabled-color`                   | `#2A4767`                | —        | —         |
+
+### Alpha variants
+
+| Token                                        | Value                                     |
+| -------------------------------------------- | ----------------------------------------- |
+| `--primary-transparent-10 / -15 / -20 / -30` | `rgba(69,208,224, .10 / .15 / .20 / .30)` |
+| `--secondary-transparent-10 / -50`           | `rgba(255,138,107, .10 / .50)`            |
+| `--accent-transparent-10 / -50`              | `rgba(255,209,102, .10 / .50)`            |
+| `--card-bg-transparent-30 / -50 / -80`       | `rgba(22,40,60, .30 / .50 / .80)`         |
+| `--text-light-transparent-20 / -30`          | `rgba(147,175,198, .20 / .30)`            |
+| `--error-bg-transparent-10`                  | `rgba(255,107,107,0.10)`                  |
+| `--card-shadow`                              | `rgba(0,10,20,0.45)`                      |
+| `--spinner-bg`                               | `rgba(147,175,198,0.15)`                  |
+
+## Buttons
+
+4px radius. Primary carries a single reflective sheen band —
+[characteristic 4](../design/city-pop-aesthetics.md#4-chrome-glass-and-water-reflection) — but
+only when decoration is enabled.
+
+| Variant     | Fill                                  | Border                | Text              | Radius | Padding     | Hover                                  | Active            | Focus                  |
+| ----------- | ------------------------------------- | --------------------- | ----------------- | ------ | ----------- | -------------------------------------- | ----------------- | ---------------------- |
+| Primary     | `--primary-color` (+ `--decor-sheen`) | none                  | `#0E1B2A`         | `4px`  | `11px 20px` | fill → `--primary-dark`                | `translateY(1px)` | `0 0 0 3px` @ 30% aqua |
+| Secondary   | `--primary-transparent-10`            | `1px --primary-color` | `--primary-color` | `4px`  | `11px 20px` | fill → 20%                             | `translateY(1px)` | same                   |
+| Ghost       | transparent                           | `1px --border-strong` | `--text-color`    | `4px`  | `11px 20px` | fill → `--hover-bg`                    | `translateY(1px)` | same                   |
+| Destructive | `--error-color`                       | none                  | `#0E1B2A`         | `4px`  | `11px 20px` | fill → `--error-hover-color`           | `translateY(1px)` | `0 0 0 3px` @ 30% red  |
+| Disabled    | `--disabled-color`                    | none                  | `--text-disabled` | `4px`  | `11px 20px` | none                                   | none              | none                   |
+| Icon-only   | transparent                           | none                  | `--text-light`    | `4px`  | `7px`       | `--hover-bg`, text → `--primary-color` | —                 | same                   |
+
+## Spacing & layout
+
+| Token                     | Value                                               |
+| ------------------------- | --------------------------------------------------- |
+| Base unit                 | `4px`                                               |
+| `--space-1` … `--space-8` | `4 · 8 · 12 · 16 · 24 · 32 · 48 · 64px`             |
+| `--card-padding`          | `--space-5` (24px)                                  |
+| `--section-gap`           | `--space-6` (32px)                                  |
+| `--page-gutter`           | `--space-6` (32px), `--space-4` (16px) below 1100px |
+| `--content-max-width`     | `1200px` — unchanged from today                     |
+| Card list gap             | `--space-4` (16px)                                  |
+| Breakpoints               | `1100px`, `720px`                                   |
+
+## Blocks & surfaces
+
+| Block            | Background                                    | Border                      | Radius | Shadow        | Accent rule                    | Hover                                   |
+| ---------------- | --------------------------------------------- | --------------------------- | ------ | ------------- | ------------------------------ | --------------------------------------- |
+| Page             | `--background-color` (+ `--decor-gradient`)   | —                           | —      | —             | —                              | —                                       |
+| `DataCard`       | `--card-color`                                | `1px --border-color`        | `4px`  | `--shadow-sm` | 2px top bar, `--primary-color` | lift `-2px` + `--shadow-md`             |
+| `MemberCard`     | `--card-color`                                | `1px --border-color`        | `4px`  | none          | none                           | `--hover-bg`                            |
+| Modal            | `--surface-raised`                            | `1px --border-strong`       | `4px`  | `--shadow-lg` | none                           | —                                       |
+| `AppHeader`      | `--card-color` (+ sky gradient when decor on) | bottom `1px --border-color` | —      | `--shadow-sm` | none                           | —                                       |
+| `ListChips` chip | `--primary-transparent-10`                    | `1px --primary-color`       | `4px`  | none          | none                           | fill → 20%                              |
+| `Pagination`     | transparent                                   | top `1px --border-color`    | —      | none          | none                           | —                                       |
+| Form input       | `--input-bg`                                  | `1px --border-strong`       | `4px`  | none          | none                           | border → `--primary-color` + focus ring |
+| `LoginForm`      | `--card-color`                                | `1px --border-color`        | `4px`  | `--shadow-lg` | 4px top bar, `--primary-color` | —                                       |
+| Empty state      | transparent                                   | `1px dashed --border-color` | `4px`  | none          | none                           | —                                       |
+| Loading overlay  | `--card-bg-transparent-80`                    | —                           | —      | —             | —                              | —                                       |
+
+## Motion
+
+| Token             | Value                                                                      |
+| ----------------- | -------------------------------------------------------------------------- |
+| `--duration-fast` | `140ms`                                                                    |
+| `--duration-base` | `200ms`                                                                    |
+| `--ease`          | `cubic-bezier(0.2, 0.8, 0.2, 1)` — slight overshoot, buoyant               |
+| `--transition`    | `all var(--duration-base) var(--ease)`                                     |
+| Hover             | `translateY(-2px)` + shadow step on cards                                  |
+| Press             | `translateY(1px)`                                                          |
+| Reduced motion    | `@media (prefers-reduced-motion: reduce)` → durations `0ms`, no transforms |
+
+## Decorative layer
+
+Opt-in behind `[data-decor='on']` on `<html>`. Off by default.
+
+| Effect            | Token              | CSS                                                                              | Default |
+| ----------------- | ------------------ | -------------------------------------------------------------------------------- | ------- |
+| Dusk sky gradient | `--decor-gradient` | `linear-gradient(180deg, #0A1522 0%, #0E1B2A 55%, #1A2438 100%)` fixed on `body` | off     |
+| Header sky wash   | `--decor-gradient` | Same gradient, `background-attachment: fixed` on `.app__header`                  | off     |
+| Button sheen      | `--decor-sheen`    | `linear-gradient(180deg, rgba(255,255,255,.18) 0%, transparent 45%)` overlay     | off     |
+| Horizon rule      | —                  | 1px `--secondary-color` full-bleed rule between page sections                    | off     |
+| Glow / scanlines  | —                  | _not used by this theme_                                                         | —       |
+
+## Token map
+
+Paste into `:root` in `src/assets/styles/_variables.css`.
+
+```css
+:root {
+  /* fonts */
+  --font-display: 'Outfit', system-ui, sans-serif;
+  --font-body: 'Inter', system-ui, -apple-system, sans-serif;
+  --font-mono: 'IBM Plex Mono', ui-monospace, monospace;
+
+  /* type scale */
+  --text-xs: 0.64rem;
+  --text-sm: 0.8rem;
+  --text-base: 1rem;
+  --text-lg: 1.25rem;
+  --text-xl: 1.563rem;
+  --text-2xl: 1.953rem;
+  --text-3xl: 2.441rem;
+  --leading-tight: 1.2;
+  --leading-normal: 1.5;
+  --leading-relaxed: 1.6;
+  --tracking-normal: 0;
+  --tracking-wide: 0.06em;
+  --weight-normal: 400;
+  --weight-medium: 500;
+  --weight-bold: 700;
+
+  /* surfaces */
+  --background-color: #0e1b2a;
+  --card-color: #16283c;
+  --card-bg: var(--card-color);
+  --surface-raised: #1e344c;
+  --input-bg: #0a1522;
+  --hover-bg: rgba(69, 208, 224, 0.08);
+  --border-color: #2a4767;
+  --border-strong: #5f7c99;
+  --border-style: 1px solid var(--border-color);
+
+  /* content */
+  --text-color: #e6f1f7;
+  --text-light: #93afc6;
+  --text-disabled: #6d8aa1;
+  --button-text-color: #0e1b2a;
+
+  /* brand */
+  --primary-color: #45d0e0;
+  --primary-dark: #2aa7b6;
+  --secondary-color: #ff8a6b;
+  --accent-color: #ffd166;
+
+  /* status */
+  --success-color: #4fd1a0;
+  --success-text: #4fd1a0;
+  --success-bg: rgba(79, 209, 160, 0.12);
+  --error-color: #ff6b6b;
+  --error-text: #ff6b6b;
+  --error-bg: rgba(255, 107, 107, 0.12);
+  --error-hover-color: #e04e4e;
+  --disabled-color: #2a4767;
+
+  /* alpha */
+  --primary-transparent-10: rgba(69, 208, 224, 0.1);
+  --primary-transparent-15: rgba(69, 208, 224, 0.15);
+  --primary-transparent-20: rgba(69, 208, 224, 0.2);
+  --primary-transparent-30: rgba(69, 208, 224, 0.3);
+  --secondary-transparent-10: rgba(255, 138, 107, 0.1);
+  --secondary-transparent-50: rgba(255, 138, 107, 0.5);
+  --accent-transparent-10: rgba(255, 209, 102, 0.1);
+  --accent-transparent-50: rgba(255, 209, 102, 0.5);
+  --card-bg-transparent-30: rgba(22, 40, 60, 0.3);
+  --card-bg-transparent-50: rgba(22, 40, 60, 0.5);
+  --card-bg-transparent-80: rgba(22, 40, 60, 0.8);
+  --text-light-transparent-20: rgba(147, 175, 198, 0.2);
+  --text-light-transparent-30: rgba(147, 175, 198, 0.3);
+  --error-bg-transparent-10: rgba(255, 107, 107, 0.1);
+  --card-shadow: rgba(0, 10, 20, 0.45);
+  --spinner-bg: rgba(147, 175, 198, 0.15);
+
+  /* spacing */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+  --space-7: 48px;
+  --space-8: 64px;
+  --card-padding: var(--space-5);
+  --section-gap: var(--space-6);
+  --page-gutter: var(--space-6);
+  --content-max-width: 1200px;
+
+  /* shape & elevation */
+  --radius-sm: 4px;
+  --radius-md: 4px;
+  --border-radius: var(--radius-md);
+  --shadow-sm: 0 1px 2px var(--card-shadow);
+  --shadow-md: 0 4px 12px var(--card-shadow);
+  --shadow-lg: 0 12px 32px var(--card-shadow);
+  --shadow: var(--shadow-md);
+  --focus-ring: 0 0 0 3px var(--primary-transparent-30);
+
+  /* motion */
+  --duration-fast: 140ms;
+  --duration-base: 200ms;
+  --ease: cubic-bezier(0.2, 0.8, 0.2, 1);
+  --transition: all var(--duration-base) var(--ease);
+
+  /* decoration (opt-in) */
+  --decor-gradient: linear-gradient(
+    180deg,
+    #0a1522 0%,
+    #0e1b2a 55%,
+    #1a2438 100%
+  );
+  --decor-sheen: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.18) 0%,
+    transparent 45%
+  );
+}
+```
+
+## Preview
+
+```
+┌────────────────────────────────────────────────┐
+│▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔│ ← 2px #45D0E0
+
+│  D E S I G N   F O L K S                        │ ← Outfit 700 20px, +0.06em
+│                                                 │
+│  42 members · updated 3d ago                    │ ← Plex Mono 12.8px #93AFC6
+│                                                 │
+│  ╭───────────╮  ╭───────────╮                   │
+│  │   View    │  │  Curate   │                   │ ← aqua fill / aqua outline
+│  ╰───────────╯  ╰───────────╯                   │
+└────────────────────────────────────────────────┘
+   card #16283C on page #0E1B2A, 1px #2A4767, r4
+```
+
+Swatches — `#0E1B2A` `#16283C` `#2A4767` `#5F7C99` `#93AFC6` `#E6F1F7` · `#45D0E0` `#2AA7B6`
+`#FF8A6B` `#FFD166` · `#4FD1A0` `#FF6B6B`
+
+## Migration notes
+
+Beyond swapping the token block:
+
+- `app.css` — `body` must move from `--font-mono` to `--font-body`; add font preloads. If
+  decoration is enabled, `body` also needs `background-image: var(--decor-gradient)` and
+  `background-attachment: fixed`.
+- `app-header.css` — currently `background-color: var(--card-color)`; gains an optional
+  gradient layer.
+- `data-card.css` — `--card-bg` and `--hover-bg` now resolve. The existing `translateY(-2px)`
+  hover already matches this theme's motion spec; only the easing changes.
+- `action-buttons.css` — `.action-button` hard-codes `border-radius: 0`; switch to
+  `var(--radius-sm)`. The sheen is an extra `::after` layer, gated on `[data-decor='on']`.
+- **No component markup changes required.**

--- a/docs/themes/theme-b-poolside-light.md
+++ b/docs/themes/theme-b-poolside-light.md
@@ -1,0 +1,291 @@
+# Theme B — Poolside プールサイド · Light
+
+> **Mood:** Hiroshi Nagai's pool at noon. Pale sky, white concrete, deep water, a coral
+> parasol. Bright, clean, spacious.
+
+|           |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Family    | B — Poolside (プールサイド)                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| Mode      | Light                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| Intensity | **Balanced** — the default recommendation                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| Lineage   | Nagai / Ohtaki / resort AOR — the daytime lineage at full noon                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Leans on  | [#1 gradient skies](../design/city-pop-aesthetics.md#1-gradient-skies-and-time-of-day-light), [#2 flat geometry](../design/city-pop-aesthetics.md#2-flat-hard-edged-geometry), [#3 tropical accents](../design/city-pop-aesthetics.md#3-high-chroma-tropical-accents-on-a-cool-base), [#4 chrome & water](../design/city-pop-aesthetics.md#4-chrome-glass-and-water-reflection), [#7 negative space](../design/city-pop-aesthetics.md#7-album-cover-composition-and-negative-space) |
+| Avoids    | Scanlines, glitch, neon glow                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+
+## Typography
+
+Identical to the dark variant — typography does not change between modes.
+
+| Element                            | Value                                                                      |
+| ---------------------------------- | -------------------------------------------------------------------------- |
+| Display / headings                 | `Outfit` — geometric sans, Latin                                           |
+| Body                               | `Inter`                                                                    |
+| Data (handles, DIDs, counts, URIs) | `IBM Plex Mono`                                                            |
+| Fallback stack                     | `system-ui, sans-serif` throughout                                         |
+| Weights loaded                     | Outfit 500/700 · Inter 400/500/600 · Plex Mono 400                         |
+| Delivery                           | `@nuxt/fonts` — self-hosted, subset, `font-display: swap`                  |
+| Base size                          | `16px`                                                                     |
+| Scale ratio                        | **1.250** (major third)                                                    |
+| `--text-3xl`                       | `2.441rem` / 39px                                                          |
+| `--text-2xl`                       | `1.953rem` / 31.2px                                                        |
+| `--text-xl`                        | `1.563rem` / 25px                                                          |
+| `--text-lg`                        | `1.250rem` / 20px                                                          |
+| `--text-base`                      | `1rem` / 16px                                                              |
+| `--text-sm`                        | `0.800rem` / 12.8px                                                        |
+| `--text-xs`                        | `0.640rem` / 10.2px                                                        |
+| Line height                        | Headings `1.2` · body `1.6`                                                |
+| Tracking                           | Display `0.06em` · body `0`                                                |
+| Casing                             | Display headings `uppercase` at `--text-lg` and below; sentence case above |
+
+## Colour
+
+Ratios measured against `--background-color` and `--card-color`; the lower is shown.
+
+### Surfaces
+
+The card is pure white against a tinted sky-blue page — the "white concrete beside blue water"
+relationship, and it makes cards read as objects sitting on the page rather than holes in it.
+
+| Token                        | Value                  | Role                         | Contrast | Verdict    |
+| ---------------------------- | ---------------------- | ---------------------------- | -------- | ---------- |
+| `--background-color`         | `#EAF6FA`              | Page — pale sky              | —        | —          |
+| `--card-color` / `--card-bg` | `#FFFFFF`              | Card, panel — white concrete | —        | —          |
+| `--surface-raised`           | `#FFFFFF`              | Modal, dropdown              | —        | —          |
+| `--input-bg`                 | `#FFFFFF`              | Field fill                   | —        | —          |
+| `--hover-bg`                 | `rgba(0,112,127,0.06)` | Neutral hover wash           | —        | —          |
+| `--border-color`             | `#C3DEE9`              | Decorative separators        | 1.28     | decorative |
+| `--border-strong`            | `#6B8998`              | Form-control borders         | **3.37** | ✅ AA      |
+
+### Content
+
+| Token                 | Value     | Role                 | Contrast  | Verdict |
+| --------------------- | --------- | -------------------- | --------- | ------- |
+| `--text-color`        | `#0F2233` | Body — deep navy ink | **14.70** | ✅ AA   |
+| `--text-light`        | `#4E6B7D` | Metadata, handles    | **5.12**  | ✅ AA   |
+| `--text-disabled`     | `#6F8B9A` | Inactive             | **3.27**  | ✅ (≥3) |
+| `--button-text-color` | `#FFFFFF` | On deep-aqua fill    | **5.79**  | ✅ AA   |
+
+### Brand roles
+
+The dark variant's bright aqua `#45D0E0` is unusable as text on a light page (≈1.7:1), so
+light mode inverts the relationship: the aqua goes deep and saturated, and the _background_
+carries the pale sky tone instead.
+
+| Token               | Value     | Role                         | Contrast | Verdict |
+| ------------------- | --------- | ---------------------------- | -------- | ------- |
+| `--primary-color`   | `#00707F` | Deep pool aqua — interactive | **5.26** | ✅ AA   |
+| `--primary-dark`    | `#005560` | Pressed / hover fill         | **7.72** | ✅ AA   |
+| `--secondary-color` | `#C2410C` | Coral sunset — counterpoint  | **4.70** | ✅ AA   |
+| `--accent-color`    | `#8A5406` | Sun ochre — rare highlight   | **5.69** | ✅ AA   |
+
+### Status
+
+| Token                                | Value     | Contrast | Verdict   |
+| ------------------------------------ | --------- | -------- | --------- |
+| `--success-color` / `--success-text` | `#12694F` | **6.03** | ✅ AA     |
+| `--success-bg`                       | `#E2F1EC` | —        | —         |
+| `--error-color` / `--error-text`     | `#B02020` | **6.20** | ✅ AA     |
+| `--error-bg`                         | `#FBE6E6` | —        | —         |
+| `--error-hover-color`                | `#8C1818` | —        | fill only |
+| `--disabled-color`                   | `#D8E7EE` | —        | —         |
+
+### Alpha variants
+
+| Token                                        | Value                                    |
+| -------------------------------------------- | ---------------------------------------- |
+| `--primary-transparent-10 / -15 / -20 / -30` | `rgba(0,112,127, .10 / .15 / .20 / .30)` |
+| `--secondary-transparent-10 / -50`           | `rgba(194,65,12, .10 / .50)`             |
+| `--accent-transparent-10 / -50`              | `rgba(138,84,6, .10 / .50)`              |
+| `--card-bg-transparent-30 / -50 / -80`       | `rgba(255,255,255, .30 / .50 / .80)`     |
+| `--text-light-transparent-20 / -30`          | `rgba(78,107,125, .20 / .30)`            |
+| `--error-bg-transparent-10`                  | `rgba(176,32,32,0.10)`                   |
+| `--card-shadow`                              | `rgba(15,34,51,0.10)`                    |
+| `--spinner-bg`                               | `rgba(78,107,125,0.15)`                  |
+
+## Buttons
+
+| Variant     | Fill                                  | Border                | Text              | Radius | Padding     | Hover                                  | Active            | Focus                  |
+| ----------- | ------------------------------------- | --------------------- | ----------------- | ------ | ----------- | -------------------------------------- | ----------------- | ---------------------- |
+| Primary     | `--primary-color` (+ `--decor-sheen`) | none                  | `#FFFFFF`         | `4px`  | `11px 20px` | fill → `--primary-dark`                | `translateY(1px)` | `0 0 0 3px` @ 30% aqua |
+| Secondary   | `--primary-transparent-10`            | `1px --primary-color` | `--primary-color` | `4px`  | `11px 20px` | fill → 20%                             | `translateY(1px)` | same                   |
+| Ghost       | transparent                           | `1px --border-strong` | `--text-color`    | `4px`  | `11px 20px` | fill → `--hover-bg`                    | `translateY(1px)` | same                   |
+| Destructive | `--error-color`                       | none                  | `#FFFFFF`         | `4px`  | `11px 20px` | fill → `--error-hover-color`           | `translateY(1px)` | `0 0 0 3px` @ 30% red  |
+| Disabled    | `--disabled-color`                    | none                  | `--text-disabled` | `4px`  | `11px 20px` | none                                   | none              | none                   |
+| Icon-only   | transparent                           | none                  | `--text-light`    | `4px`  | `7px`       | `--hover-bg`, text → `--primary-color` | —                 | same                   |
+
+## Spacing & layout
+
+Identical to the dark variant.
+
+| Token                     | Value                                               |
+| ------------------------- | --------------------------------------------------- |
+| Base unit                 | `4px`                                               |
+| `--space-1` … `--space-8` | `4 · 8 · 12 · 16 · 24 · 32 · 48 · 64px`             |
+| `--card-padding`          | `--space-5` (24px)                                  |
+| `--section-gap`           | `--space-6` (32px)                                  |
+| `--page-gutter`           | `--space-6` (32px), `--space-4` (16px) below 1100px |
+| `--content-max-width`     | `1200px`                                            |
+| Card list gap             | `--space-4` (16px)                                  |
+| Breakpoints               | `1100px`, `720px`                                   |
+
+## Blocks & surfaces
+
+| Block            | Background                                    | Border                      | Radius | Shadow        | Accent rule                    | Hover                                   |
+| ---------------- | --------------------------------------------- | --------------------------- | ------ | ------------- | ------------------------------ | --------------------------------------- |
+| Page             | `--background-color` (+ `--decor-gradient`)   | —                           | —      | —             | —                              | —                                       |
+| `DataCard`       | `--card-color`                                | `1px --border-color`        | `4px`  | `--shadow-sm` | 2px top bar, `--primary-color` | lift `-2px` + `--shadow-md`             |
+| `MemberCard`     | `--card-color`                                | `1px --border-color`        | `4px`  | none          | none                           | `--hover-bg`                            |
+| Modal            | `--surface-raised`                            | `1px --border-strong`       | `4px`  | `--shadow-lg` | none                           | —                                       |
+| `AppHeader`      | `--card-color` (+ sky gradient when decor on) | bottom `1px --border-color` | —      | `--shadow-sm` | none                           | —                                       |
+| `ListChips` chip | `--primary-transparent-10`                    | `1px --primary-color`       | `4px`  | none          | none                           | fill → 20%                              |
+| `Pagination`     | transparent                                   | top `1px --border-color`    | —      | none          | none                           | —                                       |
+| Form input       | `--input-bg`                                  | `1px --border-strong`       | `4px`  | none          | none                           | border → `--primary-color` + focus ring |
+| `LoginForm`      | `--card-color`                                | `1px --border-color`        | `4px`  | `--shadow-lg` | 4px top bar, `--primary-color` | —                                       |
+| Empty state      | transparent                                   | `1px dashed --border-color` | `4px`  | none          | none                           | —                                       |
+| Loading overlay  | `--card-bg-transparent-80`                    | —                           | —      | —             | —                              | —                                       |
+
+## Motion
+
+Identical to the dark variant.
+
+| Token             | Value                                                                      |
+| ----------------- | -------------------------------------------------------------------------- |
+| `--duration-fast` | `140ms`                                                                    |
+| `--duration-base` | `200ms`                                                                    |
+| `--ease`          | `cubic-bezier(0.2, 0.8, 0.2, 1)`                                           |
+| `--transition`    | `all var(--duration-base) var(--ease)`                                     |
+| Hover             | `translateY(-2px)` + shadow step on cards                                  |
+| Press             | `translateY(1px)`                                                          |
+| Reduced motion    | `@media (prefers-reduced-motion: reduce)` → durations `0ms`, no transforms |
+
+## Decorative layer
+
+Opt-in behind `[data-decor='on']` on `<html>`. Off by default.
+
+| Effect            | Token              | CSS                                                                              | Default |
+| ----------------- | ------------------ | -------------------------------------------------------------------------------- | ------- |
+| Noon sky gradient | `--decor-gradient` | `linear-gradient(180deg, #D6EEF7 0%, #EAF6FA 45%, #F7FCFD 100%)` fixed on `body` | off     |
+| Header sky wash   | `--decor-gradient` | Same gradient, `background-attachment: fixed` on `.app__header`                  | off     |
+| Button sheen      | `--decor-sheen`    | `linear-gradient(180deg, rgba(255,255,255,.22) 0%, transparent 45%)` overlay     | off     |
+| Horizon rule      | —                  | 1px `--secondary-color` full-bleed rule between page sections                    | off     |
+| Glow / scanlines  | —                  | _not used by this theme_                                                         | —       |
+
+## Token map
+
+Paste into `.light-theme` in `src/assets/styles/_variables.css`.
+
+```css
+.light-theme {
+  /* surfaces */
+  --background-color: #eaf6fa;
+  --card-color: #ffffff;
+  --card-bg: var(--card-color);
+  --surface-raised: #ffffff;
+  --input-bg: #ffffff;
+  --hover-bg: rgba(0, 112, 127, 0.06);
+  --border-color: #c3dee9;
+  --border-strong: #6b8998;
+  --border-style: 1px solid var(--border-color);
+
+  /* content */
+  --text-color: #0f2233;
+  --text-light: #4e6b7d;
+  --text-disabled: #6f8b9a;
+  --button-text-color: #ffffff;
+
+  /* brand */
+  --primary-color: #00707f;
+  --primary-dark: #005560;
+  --secondary-color: #c2410c;
+  --accent-color: #8a5406;
+
+  /* status */
+  --success-color: #12694f;
+  --success-text: #12694f;
+  --success-bg: #e2f1ec;
+  --error-color: #b02020;
+  --error-text: #b02020;
+  --error-bg: #fbe6e6;
+  --error-hover-color: #8c1818;
+  --disabled-color: #d8e7ee;
+
+  /* alpha */
+  --primary-transparent-10: rgba(0, 112, 127, 0.1);
+  --primary-transparent-15: rgba(0, 112, 127, 0.15);
+  --primary-transparent-20: rgba(0, 112, 127, 0.2);
+  --primary-transparent-30: rgba(0, 112, 127, 0.3);
+  --secondary-transparent-10: rgba(194, 65, 12, 0.1);
+  --secondary-transparent-50: rgba(194, 65, 12, 0.5);
+  --accent-transparent-10: rgba(138, 84, 6, 0.1);
+  --accent-transparent-50: rgba(138, 84, 6, 0.5);
+  --card-bg-transparent-30: rgba(255, 255, 255, 0.3);
+  --card-bg-transparent-50: rgba(255, 255, 255, 0.5);
+  --card-bg-transparent-80: rgba(255, 255, 255, 0.8);
+  --text-light-transparent-20: rgba(78, 107, 125, 0.2);
+  --text-light-transparent-30: rgba(78, 107, 125, 0.3);
+  --error-bg-transparent-10: rgba(176, 32, 32, 0.1);
+  --card-shadow: rgba(15, 34, 51, 0.1);
+  --spinner-bg: rgba(78, 107, 125, 0.15);
+
+  /* shape & elevation */
+  --shadow-sm: 0 1px 2px var(--card-shadow);
+  --shadow-md: 0 4px 12px var(--card-shadow);
+  --shadow-lg: 0 12px 32px var(--card-shadow);
+  --shadow: var(--shadow-md);
+  --focus-ring: 0 0 0 3px var(--primary-transparent-30);
+
+  /* decoration (opt-in) */
+  --decor-gradient: linear-gradient(
+    180deg,
+    #d6eef7 0%,
+    #eaf6fa 45%,
+    #f7fcfd 100%
+  );
+  --decor-sheen: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.22) 0%,
+    transparent 45%
+  );
+}
+```
+
+Font, type-scale, spacing, radius and motion tokens are inherited from `:root` — they are
+mode-independent and are not redeclared here.
+
+## Preview
+
+```
+┌────────────────────────────────────────────────┐
+│▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔│ ← 2px #00707F
+
+│  D E S I G N   F O L K S                        │ ← Outfit 700 20px, +0.06em
+│                                                 │
+│  42 members · updated 3d ago                    │ ← Plex Mono 12.8px #4E6B7D
+│                                                 │
+│  ╭───────────╮  ╭───────────╮                   │
+│  │   View    │  │  Curate   │                   │ ← aqua fill / aqua outline
+│  ╰───────────╯  ╰───────────╯                   │
+└────────────────────────────────────────────────┘
+   card #FFFFFF on page #EAF6FA, 1px #C3DEE9, r4
+```
+
+Swatches — `#EAF6FA` `#FFFFFF` `#C3DEE9` `#6B8998` `#4E6B7D` `#0F2233` · `#00707F` `#005560`
+`#C2410C` `#8A5406` · `#12694F` `#B02020`
+
+## Migration notes
+
+Beyond swapping the token block:
+
+- `app.css` — `body` must move from `--font-mono` to `--font-body`; add font preloads. With
+  decoration on, `body` needs `background-image: var(--decor-gradient)` and
+  `background-attachment: fixed`.
+- `app-header.css` — gains an optional gradient layer over `--card-color`.
+- `data-card.css` — `--card-bg` and `--hover-bg` now resolve, so the modal and card action
+  hover states render for the first time.
+- `list-form.css` — `--input-bg` now resolves; white fields against the tinted page.
+- `action-buttons.css` — `.action-button` hard-codes `border-radius: 0`; switch to
+  `var(--radius-sm)`. Sheen is an extra `::after`, gated on `[data-decor='on']`.
+- **Watch out:** this theme's card is pure white while the page is tinted. Any component
+  currently assuming `--card-color` and `--background-color` are near-identical (the old light
+  theme had `#ffffff` on `#f7f7f8`) will now show a visible edge — that is intended.
+- **No component markup changes required.**

--- a/docs/themes/theme-b-poolside.html
+++ b/docs/themes/theme-b-poolside.html
@@ -1,0 +1,914 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Theme B — Poolside プールサイド · Bluelist</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono&family=Inter:wght@400;500;600&family=Outfit:wght@500;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* ─── THEME TOKENS — dark (:root) ─────────────────────────────── */
+      :root {
+        --font-display: 'Outfit', system-ui, sans-serif;
+        --font-body: 'Inter', system-ui, -apple-system, sans-serif;
+        --font-mono: 'IBM Plex Mono', ui-monospace, monospace;
+
+        --text-xs: 0.64rem;
+        --text-sm: 0.8rem;
+        --text-base: 1rem;
+        --text-lg: 1.25rem;
+        --text-xl: 1.563rem;
+        --text-2xl: 1.953rem;
+        --text-3xl: 2.441rem;
+        --leading-tight: 1.2;
+        --leading-relaxed: 1.6;
+        --tracking-wide: 0.06em;
+        --tracking-wider: 0.3em;
+        --weight-bold: 700;
+
+        --background-color: #0e1b2a;
+        --card-color: #16283c;
+        --card-bg: var(--card-color);
+        --surface-raised: #1e344c;
+        --input-bg: #0a1522;
+        --hover-bg: rgba(69, 208, 224, 0.08);
+        --border-color: #2a4767;
+        --border-strong: #5f7c99;
+        --border-style: 1px solid var(--border-color);
+
+        --text-color: #e6f1f7;
+        --text-light: #93afc6;
+        --text-disabled: #6d8aa1;
+        --button-text-color: #0e1b2a;
+
+        --primary-color: #45d0e0;
+        --primary-dark: #2aa7b6;
+        --secondary-color: #ff8a6b;
+        --accent-color: #ffd166;
+
+        --success-color: #4fd1a0;
+        --success-text: #4fd1a0;
+        --success-bg: rgba(79, 209, 160, 0.12);
+        --error-color: #ff6b6b;
+        --error-text: #ff6b6b;
+        --error-bg: rgba(255, 107, 107, 0.12);
+        --error-hover-color: #e04e4e;
+        --disabled-color: #2a4767;
+
+        --primary-transparent-10: rgba(69, 208, 224, 0.1);
+        --primary-transparent-20: rgba(69, 208, 224, 0.2);
+        --primary-transparent-30: rgba(69, 208, 224, 0.3);
+        --card-bg-transparent-80: rgba(22, 40, 60, 0.8);
+        --card-shadow: rgba(0, 10, 20, 0.45);
+
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 24px;
+        --space-6: 32px;
+        --space-7: 48px;
+        --space-8: 64px;
+        --card-padding: var(--space-5);
+        --content-max-width: 1200px;
+
+        --radius-sm: 4px;
+        --radius-md: 4px;
+        --shadow-sm: 0 1px 2px var(--card-shadow);
+        --shadow-md: 0 4px 12px var(--card-shadow);
+        --shadow-lg: 0 12px 32px var(--card-shadow);
+        --focus-ring: 0 0 0 3px var(--primary-transparent-30);
+
+        --duration-base: 200ms;
+        --ease: cubic-bezier(0.2, 0.8, 0.2, 1);
+        --transition: all var(--duration-base) var(--ease);
+
+        --decor-gradient: linear-gradient(
+          180deg,
+          #0a1522 0%,
+          #0e1b2a 55%,
+          #1a2438 100%
+        );
+        --decor-sheen: linear-gradient(
+          180deg,
+          rgba(255, 255, 255, 0.18) 0%,
+          transparent 45%
+        );
+      }
+
+      /* ─── THEME TOKENS — light ────────────────────────────────────── */
+      .light-theme {
+        --background-color: #eaf6fa;
+        --card-color: #ffffff;
+        --surface-raised: #ffffff;
+        --input-bg: #ffffff;
+        --hover-bg: rgba(0, 112, 127, 0.06);
+        --border-color: #c3dee9;
+        --border-strong: #6b8998;
+
+        --text-color: #0f2233;
+        --text-light: #4e6b7d;
+        --text-disabled: #6f8b9a;
+        --button-text-color: #ffffff;
+
+        --primary-color: #00707f;
+        --primary-dark: #005560;
+        --secondary-color: #c2410c;
+        --accent-color: #8a5406;
+
+        --success-color: #12694f;
+        --success-text: #12694f;
+        --success-bg: #e2f1ec;
+        --error-color: #b02020;
+        --error-text: #b02020;
+        --error-bg: #fbe6e6;
+        --error-hover-color: #8c1818;
+        --disabled-color: #d8e7ee;
+
+        --primary-transparent-10: rgba(0, 112, 127, 0.1);
+        --primary-transparent-20: rgba(0, 112, 127, 0.2);
+        --primary-transparent-30: rgba(0, 112, 127, 0.3);
+        --card-bg-transparent-80: rgba(255, 255, 255, 0.8);
+        --card-shadow: rgba(15, 34, 51, 0.1);
+
+        --decor-gradient: linear-gradient(
+          180deg,
+          #d6eef7 0%,
+          #eaf6fa 45%,
+          #f7fcfd 100%
+        );
+        --decor-sheen: linear-gradient(
+          180deg,
+          rgba(255, 255, 255, 0.22) 0%,
+          transparent 45%
+        );
+      }
+
+      /* ─── PREVIEW CHROME ──────────────────────────────────────────── */
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family: var(--font-body);
+        background: var(--background-color);
+        color: var(--text-color);
+        line-height: var(--leading-relaxed);
+        transition: background-color var(--duration-base) var(--ease),
+          color var(--duration-base) var(--ease);
+      }
+      html[data-decor='on'] body {
+        background-image: var(--decor-gradient);
+        background-attachment: fixed;
+      }
+      html[data-decor='on'] .btn--primary {
+        background-image: var(--decor-sheen);
+      }
+      html[data-decor='on'] .mock__header {
+        background-image: var(--decor-gradient);
+      }
+      html[data-decor='on'] .horizon {
+        display: block;
+      }
+      .horizon {
+        display: none;
+        height: 1px;
+        background: var(--secondary-color);
+        margin: var(--space-6) 0;
+      }
+
+      .wrap {
+        max-width: var(--content-max-width);
+        margin: 0 auto;
+        padding: var(--space-6);
+      }
+      .bar {
+        position: sticky;
+        top: 0;
+        z-index: 9999;
+        display: flex;
+        gap: var(--space-3);
+        align-items: center;
+        flex-wrap: wrap;
+        padding: var(--space-3) var(--space-6);
+        background: var(--card-color);
+        border-bottom: var(--border-style);
+        box-shadow: var(--shadow-sm);
+      }
+      .bar__title {
+        font-family: var(--font-display);
+        font-weight: 700;
+        font-size: var(--text-lg);
+        color: var(--primary-color);
+        letter-spacing: var(--tracking-wide);
+        margin-right: auto;
+      }
+      .bar__tag {
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        color: var(--text-light);
+        border: 1px solid var(--border-color);
+        border-radius: var(--radius-sm);
+        padding: 2px 8px;
+      }
+
+      h2.sec {
+        font-family: var(--font-display);
+        font-weight: 700;
+        font-size: var(--text-2xl);
+        line-height: var(--leading-tight);
+        margin: var(--space-8) 0 var(--space-2);
+        letter-spacing: var(--tracking-wide);
+      }
+      h2.sec:first-of-type {
+        margin-top: var(--space-5);
+      }
+      .lede {
+        color: var(--text-light);
+        max-width: 62ch;
+        margin-bottom: var(--space-5);
+      }
+      .rule {
+        height: 2px;
+        background: var(--primary-color);
+        margin-bottom: var(--space-5);
+      }
+
+      .sw-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
+        gap: var(--space-3);
+      }
+      .sw {
+        border: var(--border-style);
+        border-radius: var(--radius-sm);
+        overflow: hidden;
+      }
+      .sw__chip {
+        height: 76px;
+      }
+      .sw__meta {
+        padding: var(--space-2) var(--space-3);
+        background: var(--card-color);
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        line-height: 1.8;
+      }
+      .sw__hex {
+        color: var(--text-light);
+        text-transform: uppercase;
+      }
+      .sw__ratio {
+        color: var(--success-text);
+      }
+
+      .spec > * {
+        margin-bottom: var(--space-3);
+      }
+      .spec .s3 {
+        font-family: var(--font-display);
+        font-weight: 700;
+        font-size: var(--text-3xl);
+        line-height: var(--leading-tight);
+        letter-spacing: var(--tracking-wide);
+      }
+      .spec .s2 {
+        font-family: var(--font-display);
+        font-weight: 700;
+        font-size: var(--text-2xl);
+        line-height: var(--leading-tight);
+      }
+      .spec .s1 {
+        font-family: var(--font-display);
+        font-weight: 700;
+        font-size: var(--text-xl);
+        line-height: var(--leading-tight);
+      }
+      .spec .s0 {
+        font-family: var(--font-display);
+        font-weight: 700;
+        font-size: var(--text-lg);
+        text-transform: uppercase;
+        letter-spacing: var(--tracking-wide);
+      }
+      .spec .body {
+        font-size: var(--text-base);
+        max-width: 62ch;
+      }
+      .spec .meta {
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        color: var(--text-light);
+      }
+
+      .btn-row {
+        display: flex;
+        gap: var(--space-3);
+        flex-wrap: wrap;
+        align-items: center;
+      }
+      .btn {
+        font-family: var(--font-body);
+        font-size: 0.95rem;
+        font-weight: 500;
+        border: none;
+        border-radius: var(--radius-sm);
+        padding: 11px 20px;
+        cursor: pointer;
+        transition: var(--transition);
+      }
+      .btn:active {
+        transform: translateY(1px);
+      }
+      .btn:focus-visible {
+        outline: none;
+        box-shadow: var(--focus-ring);
+      }
+      .btn--primary {
+        background-color: var(--primary-color);
+        color: var(--button-text-color);
+      }
+      .btn--primary:hover {
+        background-color: var(--primary-dark);
+      }
+      .btn--secondary {
+        background: var(--primary-transparent-10);
+        border: 1px solid var(--primary-color);
+        color: var(--primary-color);
+      }
+      .btn--secondary:hover {
+        background: var(--primary-transparent-20);
+      }
+      .btn--ghost {
+        background: transparent;
+        border: 1px solid var(--border-strong);
+        color: var(--text-color);
+      }
+      .btn--ghost:hover {
+        background: var(--hover-bg);
+      }
+      .btn--danger {
+        background: var(--error-color);
+        color: var(--button-text-color);
+      }
+      .btn--danger:hover {
+        background: var(--error-hover-color);
+      }
+      .btn--disabled {
+        background: var(--disabled-color);
+        color: var(--text-disabled);
+        cursor: not-allowed;
+      }
+      .btn--icon {
+        background: transparent;
+        color: var(--text-light);
+        padding: 7px;
+        font-size: 1.1rem;
+        line-height: 1;
+      }
+      .btn--icon:hover {
+        background: var(--hover-bg);
+        color: var(--primary-color);
+      }
+
+      .mock {
+        border: var(--border-style);
+        border-radius: var(--radius-sm);
+        overflow: hidden;
+        box-shadow: var(--shadow-md);
+      }
+      .mock__header {
+        display: flex;
+        align-items: center;
+        gap: var(--space-3);
+        padding: var(--space-4) var(--space-5);
+        background: var(--card-color);
+        border-bottom: var(--border-style);
+      }
+      .mock__logo {
+        font-family: var(--font-display);
+        font-weight: 700;
+        font-size: var(--text-xl);
+        color: var(--primary-color);
+        letter-spacing: var(--tracking-wide);
+        margin-right: auto;
+      }
+      .mock__status {
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        color: var(--text-light);
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .dot {
+        width: 8px;
+        height: 8px;
+        background: var(--success-color);
+        border-radius: 50%;
+      }
+      .mock__body {
+        padding: var(--space-5);
+        background: var(--background-color);
+        display: grid;
+        grid-template-columns: 220px 1fr;
+        gap: var(--space-5);
+      }
+      @media (max-width: 820px) {
+        .mock__body {
+          grid-template-columns: 1fr;
+        }
+      }
+      .panel {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+      }
+
+      .card {
+        background: var(--card-color);
+        border: var(--border-style);
+        border-radius: var(--radius-sm);
+        box-shadow: var(--shadow-sm);
+        padding: var(--card-padding);
+        margin-bottom: var(--space-4);
+        position: relative;
+        transition: var(--transition);
+      }
+      .card::before {
+        content: '';
+        position: absolute;
+        inset: 0 0 auto 0;
+        height: 2px;
+        background: var(--primary-color);
+      }
+      .card:hover {
+        transform: translateY(-2px);
+        box-shadow: var(--shadow-md);
+        border-color: var(--primary-color);
+      }
+      .card__title {
+        font-family: var(--font-display);
+        font-weight: 700;
+        font-size: var(--text-lg);
+        text-transform: uppercase;
+        letter-spacing: var(--tracking-wide);
+        line-height: var(--leading-tight);
+      }
+      .card__meta {
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        color: var(--text-light);
+        margin: var(--space-1) 0 var(--space-4);
+      }
+
+      .member {
+        display: flex;
+        align-items: center;
+        gap: var(--space-3);
+        background: var(--card-color);
+        border: var(--border-style);
+        border-radius: var(--radius-sm);
+        padding: var(--space-3) var(--space-4);
+        margin-bottom: 6px;
+        transition: var(--transition);
+      }
+      .member:hover {
+        background: var(--hover-bg);
+      }
+      .avatar {
+        width: 34px;
+        height: 34px;
+        border-radius: 50%;
+        background: var(--primary-transparent-20);
+        border: 1px solid var(--primary-color);
+        flex: none;
+      }
+      .member__name {
+        font-weight: 500;
+      }
+      .member__handle {
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        color: var(--text-light);
+      }
+
+      .chips {
+        display: flex;
+        gap: var(--space-2);
+        flex-wrap: wrap;
+        margin-top: var(--space-3);
+      }
+      .chip {
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        background: var(--primary-transparent-10);
+        border: 1px solid var(--primary-color);
+        border-radius: var(--radius-sm);
+        color: var(--primary-color);
+        padding: 4px 10px;
+        cursor: pointer;
+        transition: var(--transition);
+      }
+      .chip:hover {
+        background: var(--primary-transparent-20);
+      }
+      .chip--off {
+        background: var(--disabled-color);
+        border-color: var(--disabled-color);
+        color: var(--text-disabled);
+      }
+
+      .pager {
+        display: flex;
+        align-items: center;
+        gap: var(--space-3);
+        border-top: var(--border-style);
+        padding-top: var(--space-3);
+        margin-top: var(--space-4);
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        color: var(--text-light);
+      }
+      .pager button {
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        background: var(--primary-transparent-10);
+        border: 1px solid var(--primary-color);
+        color: var(--primary-color);
+        border-radius: var(--radius-sm);
+        padding: 4px 12px;
+        cursor: pointer;
+      }
+
+      .field {
+        display: block;
+        margin-bottom: var(--space-3);
+      }
+      .field label {
+        display: block;
+        font-size: var(--text-sm);
+        color: var(--text-light);
+        margin-bottom: 6px;
+      }
+      .field input {
+        width: 100%;
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        background: var(--input-bg);
+        border: 1px solid var(--border-strong);
+        border-radius: var(--radius-sm);
+        color: var(--text-color);
+        padding: 10px 12px;
+        transition: var(--transition);
+      }
+      .field input:focus {
+        outline: none;
+        border-color: var(--primary-color);
+        box-shadow: var(--focus-ring);
+      }
+
+      .note {
+        border-radius: var(--radius-sm);
+        padding: var(--space-3) var(--space-4);
+        margin-bottom: var(--space-3);
+        font-size: var(--text-sm);
+      }
+      .note--ok {
+        background: var(--success-bg);
+        color: var(--success-text);
+        border-left: 3px solid var(--success-text);
+      }
+      .note--err {
+        background: var(--error-bg);
+        color: var(--error-text);
+        border-left: 3px solid var(--error-text);
+      }
+      .empty {
+        border: 1px dashed var(--border-color);
+        border-radius: var(--radius-sm);
+        padding: var(--space-6);
+        text-align: center;
+        color: var(--text-light);
+      }
+
+      .cols {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-5);
+      }
+      @media (max-width: 820px) {
+        .cols {
+          grid-template-columns: 1fr;
+        }
+      }
+      .scale-row {
+        display: flex;
+        align-items: center;
+        gap: var(--space-3);
+        margin-bottom: 6px;
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        color: var(--text-light);
+      }
+      .scale-bar {
+        height: 14px;
+        background: var(--primary-transparent-30);
+        border-left: 2px solid var(--primary-color);
+      }
+
+      table.tk {
+        width: 100%;
+        border-collapse: collapse;
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+      }
+      table.tk th,
+      table.tk td {
+        text-align: left;
+        padding: 8px 10px;
+        border-bottom: var(--border-style);
+      }
+      table.tk th {
+        color: var(--text-light);
+        font-weight: 400;
+      }
+      .ok {
+        color: var(--success-text);
+      }
+
+      footer.f {
+        margin-top: var(--space-8);
+        padding-top: var(--space-5);
+        border-top: var(--border-style);
+        color: var(--text-light);
+        font-size: var(--text-sm);
+      }
+      footer.f a {
+        color: var(--primary-color);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="bar">
+      <div class="bar__title">Theme B — Poolside プールサイド</div>
+      <span class="bar__tag">balanced · recommended</span>
+      <button class="btn btn--secondary" id="mode">◐ Light mode</button>
+      <button class="btn btn--ghost" id="decor">Decoration: off</button>
+    </div>
+
+    <div class="wrap">
+      <h2 class="sec">Overview</h2>
+      <div class="rule"></div>
+      <p class="lede">
+        Hiroshi Nagai's pool — at dusk in dark mode, at noon in light. Deep sky
+        navy and lit water against a coral sun; or pale sky, white concrete and
+        deep aqua. This family carries five of the eight city pop
+        characteristics, including the gradient skies and cool/warm/highlight
+        accent structure that most define Nagai's covers.
+      </p>
+      <div class="horizon"></div>
+
+      <h2 class="sec">Palette</h2>
+      <div class="rule"></div>
+      <p class="lede">
+        Cool primary, warm secondary, high-attention tertiary. Every value is
+        checked against both the page and the card background; the figure shown
+        is the lower of the two.
+      </p>
+      <div class="sw-grid" id="swatches"></div>
+
+      <h2 class="sec">Typography</h2>
+      <div class="rule"></div>
+      <p class="lede">
+        Outfit for headings with 0.06em tracking, Inter for body, IBM Plex Mono
+        for data. Scale ratio 1.250. Smaller headings go uppercase — the sleeve
+        lettering register.
+      </p>
+      <div class="spec">
+        <div class="s3">Organise your follows</div>
+        <div class="s2">Design Folks</div>
+        <div class="s1">42 members</div>
+        <div class="s0">Suggested lists</div>
+        <p class="body">
+          Body copy is Inter at 16px with a 1.6 line height. The geometric
+          display face carries the personality in the chrome, while the long
+          member lists this app is mostly made of stay quiet and legible.
+        </p>
+        <div class="meta">@samuel.bsky.social · did:plc:7f3k… · 3d ago</div>
+      </div>
+
+      <h2 class="sec">Buttons</h2>
+      <div class="rule"></div>
+      <p class="lede">
+        4px radius. Turn decoration on to add the reflective sheen band to the
+        primary button — the pool-surface lever.
+      </p>
+      <div class="btn-row">
+        <button class="btn btn--primary">View list</button>
+        <button class="btn btn--secondary">Curate with AI</button>
+        <button class="btn btn--ghost">Cancel</button>
+        <button class="btn btn--danger">Delete list</button>
+        <button class="btn btn--disabled" disabled>Unavailable</button>
+        <button class="btn btn--icon" title="Edit">✎</button>
+        <button class="btn btn--icon" title="Delete">🗑</button>
+      </div>
+
+      <h2 class="sec">Interface</h2>
+      <div class="rule"></div>
+      <p class="lede">Hover a card to see the 2px lift and shadow step.</p>
+      <div class="mock">
+        <div class="mock__header">
+          <div class="mock__logo">bluelist</div>
+          <div class="mock__status">
+            <span class="dot"></span>@samuel.bsky.social
+          </div>
+          <button class="btn btn--icon" title="Toggle theme">☾</button>
+        </div>
+        <div class="mock__body">
+          <div class="panel">
+            <button class="btn btn--secondary">Get timeline</button>
+            <button class="btn btn--secondary">Get follows</button>
+            <button class="btn btn--secondary">Get lists</button>
+            <button class="btn btn--primary">Curate</button>
+          </div>
+          <div>
+            <div class="card">
+              <div class="card__title">Design Folks</div>
+              <div class="card__meta">42 members · updated 3d ago</div>
+              <div class="member">
+                <div class="avatar"></div>
+                <div>
+                  <div class="member__name">Mariya Takeuchi</div>
+                  <div class="member__handle">@mariya.bsky.social</div>
+                </div>
+              </div>
+              <div class="member">
+                <div class="avatar"></div>
+                <div>
+                  <div class="member__name">Tatsuro Yamashita</div>
+                  <div class="member__handle">@tatsuro.bsky.social</div>
+                </div>
+              </div>
+              <div class="chips">
+                <span class="chip">Design Folks</span>
+                <span class="chip">Music</span>
+                <span class="chip chip--off">Archived</span>
+              </div>
+              <div class="pager">
+                <button>‹ Prev</button>
+                <span>Page 2 of 7</span>
+                <button>Next ›</button>
+              </div>
+            </div>
+            <div class="note note--ok">Added 3 users to “Design Folks”.</div>
+            <div class="note note--err">
+              Token has expired — please sign in again.
+            </div>
+            <div class="empty">No lists yet. Create one to get started.</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="cols">
+        <div>
+          <h2 class="sec">Form</h2>
+          <div class="rule"></div>
+          <div class="field">
+            <label>List name</label>
+            <input value="Design Folks" />
+          </div>
+          <div class="field">
+            <label>Description</label>
+            <input placeholder="Focus this input to see the ring" />
+          </div>
+          <div class="btn-row">
+            <button class="btn btn--primary">Save</button>
+            <button class="btn btn--ghost">Cancel</button>
+          </div>
+        </div>
+        <div>
+          <h2 class="sec">Spacing</h2>
+          <div class="rule"></div>
+          <div id="scale"></div>
+          <p class="lede" style="margin-top: var(--space-4)">
+            4px base unit. Card padding 24px, section gap 32px, content width
+            1200px — unchanged from today.
+          </p>
+        </div>
+      </div>
+
+      <h2 class="sec">Contrast record</h2>
+      <div class="rule"></div>
+      <table class="tk" id="contrast"></table>
+
+      <footer class="f">
+        Full specification:
+        <a href="theme-b-poolside-dark.md">dark</a> ·
+        <a href="theme-b-poolside-light.md">light</a> ·
+        <a href="index.html">compare all three families</a><br />
+        Fonts load from Google Fonts in this preview only; production is
+        self-hosted WOFF2, subset, <code>font-display: swap</code>.
+      </footer>
+    </div>
+
+    <script>
+      const SW = {
+        dark: [
+          ['--background-color', '#0E1B2A', 'page · dusk navy', ''],
+          ['--card-color', '#16283C', 'card', ''],
+          ['--surface-raised', '#1E344C', 'modal', ''],
+          ['--border-color', '#2A4767', 'separator', ''],
+          ['--border-strong', '#5F7C99', 'control border', '3.44'],
+          ['--text-disabled', '#6D8AA1', 'inactive', '4.13'],
+          ['--text-light', '#93AFC6', 'metadata', '6.55'],
+          ['--text-color', '#E6F1F7', 'body', '13.04'],
+          ['--primary-color', '#45D0E0', 'pool aqua · interactive', '8.09'],
+          ['--primary-dark', '#2AA7B6', 'pressed', '5.20'],
+          ['--secondary-color', '#FF8A6B', 'coral · counterpoint', '6.49'],
+          ['--accent-color', '#FFD166', 'sun · highlight', '10.38'],
+          ['--success-color', '#4FD1A0', 'success', '7.81'],
+          ['--error-color', '#FF6B6B', 'error', '5.39'],
+        ],
+        light: [
+          ['--background-color', '#EAF6FA', 'page · pale sky', ''],
+          ['--card-color', '#FFFFFF', 'card · white concrete', ''],
+          ['--surface-raised', '#FFFFFF', 'modal', ''],
+          ['--border-color', '#C3DEE9', 'separator', ''],
+          ['--border-strong', '#6B8998', 'control border', '3.37'],
+          ['--text-disabled', '#6F8B9A', 'inactive', '3.27'],
+          ['--text-light', '#4E6B7D', 'metadata', '5.12'],
+          ['--text-color', '#0F2233', 'body', '14.70'],
+          ['--primary-color', '#00707F', 'deep aqua · interactive', '5.26'],
+          ['--primary-dark', '#005560', 'pressed', '7.72'],
+          ['--secondary-color', '#C2410C', 'coral · counterpoint', '4.70'],
+          ['--accent-color', '#8A5406', 'sun ochre · highlight', '5.69'],
+          ['--success-color', '#12694F', 'success', '6.03'],
+          ['--error-color', '#B02020', 'error', '6.20'],
+        ],
+      };
+
+      const root = document.documentElement;
+      const isLight = () => root.classList.contains('light-theme');
+
+      function render() {
+        const rows = isLight() ? SW.light : SW.dark;
+        document.getElementById('swatches').innerHTML = rows
+          .map(
+            ([t, hex, role, ratio]) => `
+        <div class="sw">
+          <div class="sw__chip" style="background:${hex}"></div>
+          <div class="sw__meta">
+            <div>${role}</div>
+            <div class="sw__hex">${hex}</div>
+            <div class="sw__ratio">${ratio ? ratio + ':1 ✓' : '&nbsp;'}</div>
+          </div>
+        </div>`
+          )
+          .join('');
+        document.getElementById('contrast').innerHTML =
+          '<tr><th>Token</th><th>Value</th><th>Role</th><th>Ratio</th></tr>' +
+          rows
+            .map(
+              ([t, hex, role, ratio]) =>
+                `<tr><td>${t}</td><td>${hex}</td><td>${role}</td><td class="ok">${
+                  ratio ? ratio + ':1' : '—'
+                }</td></tr>`
+            )
+            .join('');
+      }
+
+      document.getElementById('scale').innerHTML = [
+        4, 8, 12, 16, 24, 32, 48, 64,
+      ]
+        .map(
+          (v, i) =>
+            `<div class="scale-row"><span style="width:70px">--space-${
+              i + 1
+            }</span><div class="scale-bar" style="width:${
+              v * 2
+            }px"></div><span>${v}px</span></div>`
+        )
+        .join('');
+
+      document.getElementById('mode').onclick = (e) => {
+        root.classList.toggle('light-theme');
+        e.target.textContent = isLight() ? '◑ Dark mode' : '◐ Light mode';
+        render();
+      };
+      document.getElementById('decor').onclick = (e) => {
+        const on = root.getAttribute('data-decor') === 'on';
+        root.setAttribute('data-decor', on ? 'off' : 'on');
+        e.target.textContent =
+          'Decoration: ' + (on ? 'off' : 'on (sky + sheen)');
+      };
+
+      render();
+    </script>
+  </body>
+</html>

--- a/docs/themes/theme-c-bayside-neon-dark.md
+++ b/docs/themes/theme-c-bayside-neon-dark.md
@@ -1,0 +1,366 @@
+# Theme C — Bayside Neon 湾岸ネオン · Dark
+
+> **Mood:** the Tokyo bayfront at 2am. Ink-violet black, magenta signage reflected in wet
+> asphalt, cyan cutting through. _Plastic Love_ on the car stereo.
+
+|           |                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Family    | C — Bayside Neon (湾岸ネオン, "bayside neon")                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| Mode      | Dark                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| Intensity | **Maximalist** — highest risk, highest personality                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| Lineage   | The nighttime lineage — Plastic Love, vaporwave, future funk                                                                                                                                                                                                                                                                                                                                                                                                           |
+| Leans on  | [#3 tropical accents](../design/city-pop-aesthetics.md#3-high-chroma-tropical-accents-on-a-cool-base), [#4 chrome](../design/city-pop-aesthetics.md#4-chrome-glass-and-water-reflection), [#5 bilingual type](../design/city-pop-aesthetics.md#5-bilingual-typographic-pairing), [#6 grids & horizons](../design/city-pop-aesthetics.md#6-horizon-lines-rules-and-perspective-grids), [#8 analog nostalgia](../design/city-pop-aesthetics.md#8-analog-nostalgia-layer) |
+| Avoids    | Nothing. This is the loud one.                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+
+> **Risk note.** This theme is the most likely to read as pastiche and the most likely to
+> fatigue on the dense, repetitive surfaces Bluelist is mostly made of (`MemberCard` lists,
+> `Pagination`). Its saturated colours are confined to chrome, headings and accents; body rows
+> stay on `--text-color` and `--text-light`, both of which clear AA comfortably. The
+> decorative layer — scanlines, glow, chrome sheen — is off by default.
+
+## Typography
+
+Wide, heavy display lettering is the signature. Confined to headings; body copy stays Inter.
+
+| Element                            | Value                                                                |
+| ---------------------------------- | -------------------------------------------------------------------- |
+| Display / headings                 | `Chakra Petch` 700 — wide techno sans, Latin                         |
+| Body                               | `Inter`                                                              |
+| Data (handles, DIDs, counts, URIs) | `IBM Plex Mono`                                                      |
+| Kana micro-labels                  | `Zen Kaku Gothic New` 500                                            |
+| Fallback stack                     | `system-ui, sans-serif` throughout                                   |
+| Weights loaded                     | Chakra Petch 700 · Inter 400/500/600 · Plex Mono 400 · Zen Kaku 500  |
+| Delivery                           | Self-hosted WOFF2, `font-display: swap`, subset to Latin + kana used |
+| Base size                          | `16px`                                                               |
+| Scale ratio                        | **1.333** (perfect fourth) — dramatic, poster-like                   |
+| `--text-3xl`                       | `3.157rem` / 50.5px — page title                                     |
+| `--text-2xl`                       | `2.369rem` / 37.9px — h2                                             |
+| `--text-xl`                        | `1.777rem` / 28.4px — h3                                             |
+| `--text-lg`                        | `1.333rem` / 21.3px — h4, card title                                 |
+| `--text-base`                      | `1rem` / 16px — body                                                 |
+| `--text-sm`                        | `0.750rem` / 12px — metadata                                         |
+| `--text-xs`                        | `0.563rem` / 9px — kana micro-labels                                 |
+| Line height                        | Headings `1.1` · body `1.6`                                          |
+| Tracking                           | Display `0.12em` · body `0` · kana label `0.4em`                     |
+| Casing                             | All display headings `uppercase`                                     |
+
+**Kana micro-labels.** Kana above section headings at `--text-xs` / `--tracking-wider` /
+`--secondary-color`. Decorative only — never functional text.
+
+**Fullwidth note.** The vaporwave `ＡＥＳＴＨＥＴＩＣ` fullwidth convention is deliberately _not_
+used — it breaks screen readers and text selection. Wide tracking achieves the same look
+safely.
+
+## Colour
+
+Ratios measured against `--background-color` and `--card-color`; the lower is shown.
+Target ≥ 4.5:1 for text and brand roles, ≥ 3:1 for disabled text and control borders.
+
+### Surfaces
+
+| Token                        | Value                   | Role                    | Contrast | Verdict    |
+| ---------------------------- | ----------------------- | ----------------------- | -------- | ---------- |
+| `--background-color`         | `#0A0614`               | Page — ink violet-black | —        | —          |
+| `--card-color` / `--card-bg` | `#150E24`               | Card, panel             | —        | —          |
+| `--surface-raised`           | `#1E1433`               | Modal, dropdown         | —        | —          |
+| `--input-bg`                 | `#07040F`               | Field fill — recessed   | —        | —          |
+| `--hover-bg`                 | `rgba(255,77,166,0.10)` | Neutral hover wash      | —        | —          |
+| `--border-color`             | `#3A2260`               | Decorative separators   | 1.50     | decorative |
+| `--border-strong`            | `#7A63A3`               | Form-control borders    | **3.70** | ✅ AA      |
+
+### Content
+
+| Token                 | Value     | Role                       | Contrast  | Verdict |
+| --------------------- | --------- | -------------------------- | --------- | ------- |
+| `--text-color`        | `#F2E9FF` | Body — violet-tinted white | **15.96** | ✅ AA   |
+| `--text-light`        | `#A896C9` | Metadata, handles          | **7.03**  | ✅ AA   |
+| `--text-disabled`     | `#7B6C99` | Inactive                   | **3.97**  | ✅ (≥3) |
+| `--button-text-color` | `#0A0614` | On magenta fill            | **6.13**  | ✅ AA   |
+
+### Brand roles
+
+| Token               | Value     | Role                       | Contrast  | Verdict |
+| ------------------- | --------- | -------------------------- | --------- | ------- |
+| `--primary-color`   | `#FF4DA6` | Neon magenta — interactive | **6.13**  | ✅ AA   |
+| `--primary-dark`    | `#E8479A` | Pressed / hover fill       | **5.18**  | ✅ AA   |
+| `--secondary-color` | `#35E8FF` | Neon cyan — counterpoint   | **12.62** | ✅ AA   |
+| `--accent-color`    | `#B96BFF` | Violet — rare highlight    | **5.90**  | ✅ AA   |
+
+Note that `--primary-dark` is _lighter_ than `--primary-color` here. On a near-black ground a
+"darker" pressed state would disappear, so the pressed fill brightens instead — the neon-sign
+behaviour rather than the paint behaviour.
+
+### Status
+
+| Token                                | Value                   | Contrast  | Verdict   |
+| ------------------------------------ | ----------------------- | --------- | --------- |
+| `--success-color` / `--success-text` | `#3DE8B0`               | **11.93** | ✅ AA     |
+| `--success-bg`                       | `rgba(61,232,176,0.12)` | —         | —         |
+| `--error-color` / `--error-text`     | `#FF5C7A`               | **6.31**  | ✅ AA     |
+| `--error-bg`                         | `rgba(255,92,122,0.12)` | —         | —         |
+| `--error-hover-color`                | `#FF7D94`               | —         | fill only |
+| `--disabled-color`                   | `#2A1B45`               | —         | —         |
+
+### Alpha variants
+
+| Token                                        | Value                                     |
+| -------------------------------------------- | ----------------------------------------- |
+| `--primary-transparent-10 / -15 / -20 / -30` | `rgba(255,77,166, .10 / .15 / .20 / .30)` |
+| `--secondary-transparent-10 / -50`           | `rgba(53,232,255, .10 / .50)`             |
+| `--accent-transparent-10 / -50`              | `rgba(185,107,255, .10 / .50)`            |
+| `--card-bg-transparent-30 / -50 / -80`       | `rgba(21,14,36, .30 / .50 / .80)`         |
+| `--text-light-transparent-20 / -30`          | `rgba(168,150,201, .20 / .30)`            |
+| `--error-bg-transparent-10`                  | `rgba(255,92,122,0.10)`                   |
+| `--card-shadow`                              | `rgba(0,0,0,0.6)`                         |
+| `--spinner-bg`                               | `rgba(168,150,201,0.15)`                  |
+
+## Buttons
+
+Zero radius, hard edges. Primary is a magenta→violet gradient; glow appears only with
+decoration enabled.
+
+| Variant     | Fill                                       | Border                | Text              | Radius | Padding     | Hover                                    | Active            | Focus                     |
+| ----------- | ------------------------------------------ | --------------------- | ----------------- | ------ | ----------- | ---------------------------------------- | ----------------- | ------------------------- |
+| Primary     | `linear-gradient(90deg, #FF4DA6, #B96BFF)` | none                  | `#0A0614`         | `0`    | `12px 22px` | brighten + `--decor-glow`                | `translateY(2px)` | `0 0 0 3px` @ 30% magenta |
+| Secondary   | `--primary-transparent-10`                 | `1px --primary-color` | `--primary-color` | `0`    | `12px 22px` | fill → 20% + glow                        | `translateY(2px)` | same                      |
+| Ghost       | transparent                                | `1px --border-strong` | `--text-color`    | `0`    | `12px 22px` | fill → `--hover-bg`                      | `translateY(2px)` | same                      |
+| Destructive | `--error-color`                            | none                  | `#0A0614`         | `0`    | `12px 22px` | fill → `--error-hover-color`             | `translateY(2px)` | `0 0 0 3px` @ 30% red     |
+| Disabled    | `--disabled-color`                         | none                  | `--text-disabled` | `0`    | `12px 22px` | none                                     | none              | none                      |
+| Icon-only   | transparent                                | none                  | `--text-light`    | `0`    | `8px`       | `--hover-bg`, text → `--secondary-color` | —                 | same                      |
+
+## Spacing & layout
+
+Larger base unit than A and B — bigger blocks, more air, poster composition.
+
+| Token                     | Value                                               |
+| ------------------------- | --------------------------------------------------- |
+| Base unit                 | `8px`                                               |
+| `--space-1` … `--space-8` | `4 · 8 · 16 · 24 · 32 · 40 · 56 · 80px`             |
+| `--card-padding`          | `--space-4` (24px)                                  |
+| `--section-gap`           | `--space-7` (56px)                                  |
+| `--page-gutter`           | `--space-5` (32px), `--space-3` (16px) below 1100px |
+| `--content-max-width`     | `1240px`                                            |
+| Card list gap             | `--space-2` (8px) — tight rows against wide gutters |
+| Breakpoints               | `1100px`, `720px`                                   |
+
+## Blocks & surfaces
+
+| Block            | Background                                          | Border                             | Radius | Shadow        | Accent rule                        | Hover                                       |
+| ---------------- | --------------------------------------------------- | ---------------------------------- | ------ | ------------- | ---------------------------------- | ------------------------------------------- |
+| Page             | `--background-color` (+ grid horizon when decor on) | —                                  | —      | —             | —                                  | —                                           |
+| `DataCard`       | `--card-color`                                      | `1px --border-color`               | `0`    | `--shadow-md` | 3px top bar, magenta→cyan gradient | border → `--primary-color` + `--decor-glow` |
+| `MemberCard`     | `--card-color`                                      | left `2px --border-color`          | `0`    | none          | none                               | left border → `--secondary-color`           |
+| Modal            | `--surface-raised`                                  | `1px --primary-color`              | `0`    | `--shadow-lg` | 3px top gradient bar               | —                                           |
+| `AppHeader`      | `--background-color`                                | bottom `2px` magenta→cyan gradient | —      | none          | none                               | —                                           |
+| `ListChips` chip | `--primary-transparent-10`                          | `1px --primary-color`              | `0`    | none          | none                               | fill → 20% + glow                           |
+| `Pagination`     | transparent                                         | top `1px --border-color`           | —      | none          | none                               | —                                           |
+| Form input       | `--input-bg`                                        | `1px --border-strong`              | `0`    | none          | none                               | border → `--secondary-color` + focus ring   |
+| `LoginForm`      | `--card-color`                                      | `1px --primary-color`              | `0`    | `--shadow-lg` | 3px top gradient bar               | —                                           |
+| Empty state      | transparent                                         | `1px dashed --border-strong`       | `0`    | none          | none                               | —                                           |
+| Loading overlay  | `--card-bg-transparent-80`                          | —                                  | —      | —             | —                                  | —                                           |
+
+## Motion
+
+Fast and snappy — a switch, not a fade.
+
+| Token             | Value                                                                                                          |
+| ----------------- | -------------------------------------------------------------------------------------------------------------- |
+| `--duration-fast` | `100ms`                                                                                                        |
+| `--duration-base` | `140ms`                                                                                                        |
+| `--ease`          | `cubic-bezier(0.16, 1, 0.3, 1)` — sharp out                                                                    |
+| `--transition`    | `all var(--duration-base) var(--ease)`                                                                         |
+| Hover             | Glow ramp, no lift                                                                                             |
+| Press             | `translateY(2px)`                                                                                              |
+| Reduced motion    | `@media (prefers-reduced-motion: reduce)` → durations `0ms`; **also disables the scanline animation entirely** |
+
+## Decorative layer
+
+Opt-in behind `[data-decor='on']` on `<html>`. Off by default. This theme has the most to gain
+and the most to lose here.
+
+| Effect       | Token              | CSS                                                                                                                      | Default |
+| ------------ | ------------------ | ------------------------------------------------------------------------------------------------------------------------ | ------- |
+| Neon glow    | `--decor-glow`     | `0 0 12px var(--primary-transparent-30)` on hovered interactive elements                                                 | off     |
+| Scanlines    | `--decor-overlay`  | `repeating-linear-gradient(180deg, rgba(0,0,0,.14) 0 1px, transparent 1px 3px)` on `body::after`, `pointer-events: none` | off     |
+| Chrome sheen | `--decor-sheen`    | `linear-gradient(180deg, rgba(255,255,255,.22) 0%, transparent 40%)` on primary buttons                                  | off     |
+| Grid horizon | `--decor-gradient` | Perspective grid in `--primary-transparent-10`, bottom 30vh of `body`, fixed                                             | off     |
+
+**Performance.** Scanlines and the fixed grid horizon both create full-viewport composited
+layers. Both must set `pointer-events: none` and should be behind `will-change: auto` — do not
+promote them. If either causes scroll jank on the long `follows` list, drop the grid first.
+
+## Token map
+
+Paste into `:root` in `src/assets/styles/_variables.css`.
+
+```css
+:root {
+  /* fonts */
+  --font-display: 'Chakra Petch', system-ui, sans-serif;
+  --font-body: 'Inter', system-ui, -apple-system, sans-serif;
+  --font-mono: 'IBM Plex Mono', ui-monospace, monospace;
+  --font-kana: 'Zen Kaku Gothic New', var(--font-body);
+
+  /* type scale */
+  --text-xs: 0.563rem;
+  --text-sm: 0.75rem;
+  --text-base: 1rem;
+  --text-lg: 1.333rem;
+  --text-xl: 1.777rem;
+  --text-2xl: 2.369rem;
+  --text-3xl: 3.157rem;
+  --leading-tight: 1.1;
+  --leading-normal: 1.4;
+  --leading-relaxed: 1.6;
+  --tracking-normal: 0;
+  --tracking-wide: 0.12em;
+  --tracking-wider: 0.4em;
+  --weight-normal: 400;
+  --weight-medium: 500;
+  --weight-bold: 700;
+
+  /* surfaces */
+  --background-color: #0a0614;
+  --card-color: #150e24;
+  --card-bg: var(--card-color);
+  --surface-raised: #1e1433;
+  --input-bg: #07040f;
+  --hover-bg: rgba(255, 77, 166, 0.1);
+  --border-color: #3a2260;
+  --border-strong: #7a63a3;
+  --border-style: 1px solid var(--border-color);
+
+  /* content */
+  --text-color: #f2e9ff;
+  --text-light: #a896c9;
+  --text-disabled: #7b6c99;
+  --button-text-color: #0a0614;
+
+  /* brand */
+  --primary-color: #ff4da6;
+  --primary-dark: #e8479a;
+  --secondary-color: #35e8ff;
+  --accent-color: #b96bff;
+
+  /* status */
+  --success-color: #3de8b0;
+  --success-text: #3de8b0;
+  --success-bg: rgba(61, 232, 176, 0.12);
+  --error-color: #ff5c7a;
+  --error-text: #ff5c7a;
+  --error-bg: rgba(255, 92, 122, 0.12);
+  --error-hover-color: #ff7d94;
+  --disabled-color: #2a1b45;
+
+  /* alpha */
+  --primary-transparent-10: rgba(255, 77, 166, 0.1);
+  --primary-transparent-15: rgba(255, 77, 166, 0.15);
+  --primary-transparent-20: rgba(255, 77, 166, 0.2);
+  --primary-transparent-30: rgba(255, 77, 166, 0.3);
+  --secondary-transparent-10: rgba(53, 232, 255, 0.1);
+  --secondary-transparent-50: rgba(53, 232, 255, 0.5);
+  --accent-transparent-10: rgba(185, 107, 255, 0.1);
+  --accent-transparent-50: rgba(185, 107, 255, 0.5);
+  --card-bg-transparent-30: rgba(21, 14, 36, 0.3);
+  --card-bg-transparent-50: rgba(21, 14, 36, 0.5);
+  --card-bg-transparent-80: rgba(21, 14, 36, 0.8);
+  --text-light-transparent-20: rgba(168, 150, 201, 0.2);
+  --text-light-transparent-30: rgba(168, 150, 201, 0.3);
+  --error-bg-transparent-10: rgba(255, 92, 122, 0.1);
+  --card-shadow: rgba(0, 0, 0, 0.6);
+  --spinner-bg: rgba(168, 150, 201, 0.15);
+
+  /* gradients */
+  --gradient-brand: linear-gradient(90deg, #ff4da6, #b96bff);
+  --gradient-rule: linear-gradient(90deg, #ff4da6, #35e8ff);
+
+  /* spacing */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 16px;
+  --space-4: 24px;
+  --space-5: 32px;
+  --space-6: 40px;
+  --space-7: 56px;
+  --space-8: 80px;
+  --card-padding: var(--space-4);
+  --section-gap: var(--space-7);
+  --page-gutter: var(--space-5);
+  --content-max-width: 1240px;
+
+  /* shape & elevation */
+  --radius-sm: 0;
+  --radius-md: 0;
+  --border-radius: var(--radius-md);
+  --shadow-sm: 0 1px 0 var(--card-shadow);
+  --shadow-md: 0 4px 16px var(--card-shadow);
+  --shadow-lg: 0 16px 48px var(--card-shadow);
+  --shadow: var(--shadow-md);
+  --focus-ring: 0 0 0 3px var(--primary-transparent-30);
+
+  /* motion */
+  --duration-fast: 100ms;
+  --duration-base: 140ms;
+  --ease: cubic-bezier(0.16, 1, 0.3, 1);
+  --transition: all var(--duration-base) var(--ease);
+
+  /* decoration (opt-in) */
+  --decor-glow: 0 0 12px var(--primary-transparent-30);
+  --decor-sheen: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.22) 0%,
+    transparent 40%
+  );
+  --decor-overlay: repeating-linear-gradient(
+    180deg,
+    rgba(0, 0, 0, 0.14) 0 1px,
+    transparent 1px 3px
+  );
+  --decor-gradient: linear-gradient(
+    180deg,
+    transparent 70%,
+    var(--primary-transparent-10) 100%
+  );
+}
+```
+
+## Preview
+
+```
+┌────────────────────────────────────────────────┐
+│████████████████████████████████████████████████│ ← 3px magenta→cyan gradient
+│  リスト                                          │ ← kana, 9px #35E8FF, +0.4em
+│  D E S I G N   F O L K S                        │ ← Chakra Petch 700 21.3px
+│                                                 │   uppercase, +0.12em #F2E9FF
+│  42 members · updated 3d ago                    │ ← Plex Mono 12px #A896C9
+│                                                 │
+│  ┏━━━━━━━━━━━┓  ┏━━━━━━━━━━━┓                   │
+│  ┃   VIEW    ┃  ┃  CURATE   ┃                   │ ← magenta→violet / outline
+│  ┗━━━━━━━━━━━┛  ┗━━━━━━━━━━━┛                   │
+└────────────────────────────────────────────────┘
+   card #150E24 on page #0A0614, 1px #3A2260, r0
+```
+
+Swatches — `#0A0614` `#150E24` `#3A2260` `#7A63A3` `#A896C9` `#F2E9FF` · `#FF4DA6` `#E8479A`
+`#35E8FF` `#B96BFF` · `#3DE8B0` `#FF5C7A`
+
+## Migration notes
+
+This theme requires the most work beyond a token swap.
+
+- `app.css` — `body` moves to `--font-body`; add font preloads. With decoration on, `body`
+  needs an `::after` scanline layer and a fixed grid-horizon background.
+- `app-header.css` — the bottom border becomes a gradient, so `border-bottom` must be replaced
+  with a `::after` bar (gradients cannot be used as `border-color`). **This is a real CSS
+  change, not just a token swap.**
+- `data-card.css` — same for `.data-card::before`: it already is a `::before` bar, so it only
+  needs `background-color` → `background-image: var(--gradient-rule)`.
+- `action-buttons.css` — `border-radius: 0` already matches. Primary buttons need a gradient
+  `background-image` plus a `::after` sheen layer gated on `[data-decor='on']`.
+- `data-display.css`, `dashboard.css` — the larger `--space-*` scale changes list density
+  noticeably; these two files carry the most hard-coded padding and will need the most review.
+- **Markup change required:** the gradient rules on `AppHeader` and the modal need a
+  pseudo-element that does not exist yet, so `AppHeader.vue` may need an extra element if a
+  pseudo-element is unavailable on the current structure.
+- **Accessibility:** verify the scanline overlay does not trip
+  `prefers-reduced-motion`; it is static, but any animated variant must be gated.

--- a/docs/themes/theme-c-bayside-neon-light.md
+++ b/docs/themes/theme-c-bayside-neon-light.md
@@ -1,0 +1,314 @@
+# Theme C — Bayside Neon 湾岸ネオン · Light
+
+> **Mood:** the mall at midday, 1991. Chrome, glass, lilac-white tile, magenta signage.
+> The daylight side of the vaporwave lineage — bright, synthetic, unashamed.
+
+|           |                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Family    | C — Bayside Neon (湾岸ネオン, "bayside neon")                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| Mode      | Light                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| Intensity | **Maximalist** — highest risk, highest personality                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| Lineage   | The nighttime lineage inverted — mallsoft, chrome, Memphis geometry                                                                                                                                                                                                                                                                                                                                                                                                    |
+| Leans on  | [#3 tropical accents](../design/city-pop-aesthetics.md#3-high-chroma-tropical-accents-on-a-cool-base), [#4 chrome](../design/city-pop-aesthetics.md#4-chrome-glass-and-water-reflection), [#5 bilingual type](../design/city-pop-aesthetics.md#5-bilingual-typographic-pairing), [#6 grids & horizons](../design/city-pop-aesthetics.md#6-horizon-lines-rules-and-perspective-grids), [#8 analog nostalgia](../design/city-pop-aesthetics.md#8-analog-nostalgia-layer) |
+| Avoids    | Nothing. This is the loud one.                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+
+> **Risk note.** Light mode is where this family is hardest to pull off — neon relies on a
+> dark ground to glow. The translation used here is **chrome instead of glow**: hard offset
+> shadows, gradient rules, and deeply saturated ink-magenta rather than luminous magenta.
+> The glow token is deliberately near-inert in this mode.
+
+## Typography
+
+Identical to the dark variant — typography does not change between modes.
+
+| Element                            | Value                                                                |
+| ---------------------------------- | -------------------------------------------------------------------- |
+| Display / headings                 | `Chakra Petch` 700 — wide techno sans, Latin                         |
+| Body                               | `Inter`                                                              |
+| Data (handles, DIDs, counts, URIs) | `IBM Plex Mono`                                                      |
+| Kana micro-labels                  | `Zen Kaku Gothic New` 500                                            |
+| Fallback stack                     | `system-ui, sans-serif` throughout                                   |
+| Weights loaded                     | Chakra Petch 700 · Inter 400/500/600 · Plex Mono 400 · Zen Kaku 500  |
+| Delivery                           | Self-hosted WOFF2, `font-display: swap`, subset to Latin + kana used |
+| Base size                          | `16px`                                                               |
+| Scale ratio                        | **1.333** (perfect fourth)                                           |
+| `--text-3xl`                       | `3.157rem` / 50.5px                                                  |
+| `--text-2xl`                       | `2.369rem` / 37.9px                                                  |
+| `--text-xl`                        | `1.777rem` / 28.4px                                                  |
+| `--text-lg`                        | `1.333rem` / 21.3px                                                  |
+| `--text-base`                      | `1rem` / 16px                                                        |
+| `--text-sm`                        | `0.750rem` / 12px                                                    |
+| `--text-xs`                        | `0.563rem` / 9px                                                     |
+| Line height                        | Headings `1.1` · body `1.6`                                          |
+| Tracking                           | Display `0.12em` · body `0` · kana label `0.4em`                     |
+| Casing                             | All display headings `uppercase`                                     |
+
+**Fullwidth note.** The `ＡＥＳＴＨＥＴＩＣ` fullwidth convention is deliberately _not_ used — it
+breaks screen readers and text selection. Wide tracking achieves the look safely.
+
+## Colour
+
+Ratios measured against `--background-color` and `--card-color`; the lower is shown.
+
+### Surfaces
+
+| Token                        | Value                 | Role                       | Contrast | Verdict    |
+| ---------------------------- | --------------------- | -------------------------- | -------- | ---------- |
+| `--background-color`         | `#F6F0FA`             | Page — lilac-white tile    | —        | —          |
+| `--card-color` / `--card-bg` | `#FFFFFF`             | Card, panel — chrome white | —        | —          |
+| `--surface-raised`           | `#FFFFFF`             | Modal, dropdown            | —        | —          |
+| `--input-bg`                 | `#FFFFFF`             | Field fill                 | —        | —          |
+| `--hover-bg`                 | `rgba(194,0,94,0.06)` | Neutral hover wash         | —        | —          |
+| `--border-color`             | `#E2D0F0`             | Decorative separators      | 1.29     | decorative |
+| `--border-strong`            | `#9585A8`             | Form-control borders       | **3.03** | ✅ AA      |
+
+### Content
+
+| Token                 | Value     | Role                    | Contrast  | Verdict |
+| --------------------- | --------- | ----------------------- | --------- | ------- |
+| `--text-color`        | `#1A0E2E` | Body — violet-black ink | **16.37** | ✅ AA   |
+| `--text-light`        | `#6B5B85` | Metadata, handles       | **5.42**  | ✅ AA   |
+| `--text-disabled`     | `#7E7095` | Inactive                | **4.04**  | ✅ (≥3) |
+| `--button-text-color` | `#FFFFFF` | On ink-magenta fill     | **6.08**  | ✅ AA   |
+
+### Brand roles
+
+The dark variant's `#FF4DA6` reaches only ≈2.3:1 on a light ground, so light mode drops the
+magenta into ink territory. The cyan likewise becomes a deep teal.
+
+| Token               | Value     | Role                      | Contrast | Verdict |
+| ------------------- | --------- | ------------------------- | -------- | ------- |
+| `--primary-color`   | `#C2005E` | Ink magenta — interactive | **5.43** | ✅ AA   |
+| `--primary-dark`    | `#99004A` | Pressed / hover fill      | **7.65** | ✅ AA   |
+| `--secondary-color` | `#006B85` | Deep cyan — counterpoint  | **5.45** | ✅ AA   |
+| `--accent-color`    | `#6D28D9` | Violet — rare highlight   | **6.35** | ✅ AA   |
+
+### Status
+
+| Token                                | Value     | Contrast | Verdict   |
+| ------------------------------------ | --------- | -------- | --------- |
+| `--success-color` / `--success-text` | `#0F6B4F` | **5.80** | ✅ AA     |
+| `--success-bg`                       | `#E2F2EC` | —        | —         |
+| `--error-color` / `--error-text`     | `#B3123C` | **6.11** | ✅ AA     |
+| `--error-bg`                         | `#FBE4EA` | —        | —         |
+| `--error-hover-color`                | `#8E0D30` | —        | fill only |
+| `--disabled-color`                   | `#EBE0F4` | —        | —         |
+
+### Alpha variants
+
+| Token                                        | Value                                   |
+| -------------------------------------------- | --------------------------------------- |
+| `--primary-transparent-10 / -15 / -20 / -30` | `rgba(194,0,94, .10 / .15 / .20 / .30)` |
+| `--secondary-transparent-10 / -50`           | `rgba(0,107,133, .10 / .50)`            |
+| `--accent-transparent-10 / -50`              | `rgba(109,40,217, .10 / .50)`           |
+| `--card-bg-transparent-30 / -50 / -80`       | `rgba(255,255,255, .30 / .50 / .80)`    |
+| `--text-light-transparent-20 / -30`          | `rgba(107,91,133, .20 / .30)`           |
+| `--error-bg-transparent-10`                  | `rgba(179,18,60,0.10)`                  |
+| `--card-shadow`                              | `rgba(26,14,46,0.16)`                   |
+| `--spinner-bg`                               | `rgba(107,91,133,0.15)`                 |
+
+## Buttons
+
+Zero radius, hard edges, **hard offset shadow instead of glow** — the chrome translation.
+
+| Variant     | Fill                                       | Border                | Text              | Radius | Padding     | Hover                                    | Active                              | Focus                     |
+| ----------- | ------------------------------------------ | --------------------- | ----------------- | ------ | ----------- | ---------------------------------------- | ----------------------------------- | ------------------------- |
+| Primary     | `linear-gradient(90deg, #C2005E, #6D28D9)` | none                  | `#FFFFFF`         | `0`    | `12px 22px` | offset shadow `3px 3px 0 --accent-color` | `translate(2px,2px)`, shadow → none | `0 0 0 3px` @ 30% magenta |
+| Secondary   | `--primary-transparent-10`                 | `1px --primary-color` | `--primary-color` | `0`    | `12px 22px` | fill → 20% + offset shadow               | `translate(2px,2px)`                | same                      |
+| Ghost       | transparent                                | `1px --border-strong` | `--text-color`    | `0`    | `12px 22px` | fill → `--hover-bg`                      | `translate(2px,2px)`                | same                      |
+| Destructive | `--error-color`                            | none                  | `#FFFFFF`         | `0`    | `12px 22px` | fill → `--error-hover-color`             | `translate(2px,2px)`                | `0 0 0 3px` @ 30% red     |
+| Disabled    | `--disabled-color`                         | none                  | `--text-disabled` | `0`    | `12px 22px` | none                                     | none                                | none                      |
+| Icon-only   | transparent                                | none                  | `--text-light`    | `0`    | `8px`       | `--hover-bg`, text → `--secondary-color` | —                                   | same                      |
+
+## Spacing & layout
+
+Identical to the dark variant.
+
+| Token                     | Value                                               |
+| ------------------------- | --------------------------------------------------- |
+| Base unit                 | `8px`                                               |
+| `--space-1` … `--space-8` | `4 · 8 · 16 · 24 · 32 · 40 · 56 · 80px`             |
+| `--card-padding`          | `--space-4` (24px)                                  |
+| `--section-gap`           | `--space-7` (56px)                                  |
+| `--page-gutter`           | `--space-5` (32px), `--space-3` (16px) below 1100px |
+| `--content-max-width`     | `1240px`                                            |
+| Card list gap             | `--space-2` (8px)                                   |
+| Breakpoints               | `1100px`, `720px`                                   |
+
+## Blocks & surfaces
+
+| Block            | Background                                          | Border                             | Radius | Shadow        | Accent rule                        | Hover                                      |
+| ---------------- | --------------------------------------------------- | ---------------------------------- | ------ | ------------- | ---------------------------------- | ------------------------------------------ |
+| Page             | `--background-color` (+ grid horizon when decor on) | —                                  | —      | —             | —                                  | —                                          |
+| `DataCard`       | `--card-color`                                      | `1px --border-color`               | `0`    | `--shadow-sm` | 3px top bar, magenta→cyan gradient | border → `--primary-color` + offset shadow |
+| `MemberCard`     | `--card-color`                                      | left `2px --border-color`          | `0`    | none          | none                               | left border → `--secondary-color`          |
+| Modal            | `--surface-raised`                                  | `1px --primary-color`              | `0`    | `--shadow-lg` | 3px top gradient bar               | —                                          |
+| `AppHeader`      | `--card-color`                                      | bottom `2px` magenta→cyan gradient | —      | `--shadow-sm` | none                               | —                                          |
+| `ListChips` chip | `--primary-transparent-10`                          | `1px --primary-color`              | `0`    | none          | none                               | fill → 20%                                 |
+| `Pagination`     | transparent                                         | top `1px --border-color`           | —      | none          | none                               | —                                          |
+| Form input       | `--input-bg`                                        | `1px --border-strong`              | `0`    | none          | none                               | border → `--secondary-color` + focus ring  |
+| `LoginForm`      | `--card-color`                                      | `1px --primary-color`              | `0`    | `--shadow-lg` | 3px top gradient bar               | —                                          |
+| Empty state      | transparent                                         | `1px dashed --border-strong`       | `0`    | none          | none                               | —                                          |
+| Loading overlay  | `--card-bg-transparent-80`                          | —                                  | —      | —             | —                                  | —                                          |
+
+## Motion
+
+Identical to the dark variant.
+
+| Token             | Value                                                                        |
+| ----------------- | ---------------------------------------------------------------------------- |
+| `--duration-fast` | `100ms`                                                                      |
+| `--duration-base` | `140ms`                                                                      |
+| `--ease`          | `cubic-bezier(0.16, 1, 0.3, 1)`                                              |
+| `--transition`    | `all var(--duration-base) var(--ease)`                                       |
+| Hover             | Offset-shadow appear, no lift                                                |
+| Press             | `translate(2px, 2px)`, shadow collapses — the button "presses into" the page |
+| Reduced motion    | `@media (prefers-reduced-motion: reduce)` → durations `0ms`                  |
+
+## Decorative layer
+
+Opt-in behind `[data-decor='on']` on `<html>`. Off by default.
+
+| Effect        | Token              | CSS                                                                                                               | Default |
+| ------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------- | ------- |
+| Chrome offset | `--decor-glow`     | `3px 3px 0 var(--accent-color)` on hovered interactive elements — replaces the dark mode's neon glow              | off     |
+| Halftone      | `--decor-overlay`  | `radial-gradient` dot grid at `opacity: .04`, `mix-blend-mode: multiply` on `body::after`, `pointer-events: none` | off     |
+| Chrome sheen  | `--decor-sheen`    | `linear-gradient(180deg, rgba(255,255,255,.35) 0%, transparent 40%)` on primary buttons                           | off     |
+| Grid horizon  | `--decor-gradient` | Perspective grid in `--primary-transparent-10`, bottom 30vh of `body`, fixed                                      | off     |
+
+**Performance.** Halftone and the fixed grid horizon both create full-viewport composited
+layers. Both must set `pointer-events: none`. If either causes scroll jank on the long
+`follows` list, drop the grid first.
+
+## Token map
+
+Paste into `.light-theme` in `src/assets/styles/_variables.css`.
+
+```css
+.light-theme {
+  /* surfaces */
+  --background-color: #f6f0fa;
+  --card-color: #ffffff;
+  --card-bg: var(--card-color);
+  --surface-raised: #ffffff;
+  --input-bg: #ffffff;
+  --hover-bg: rgba(194, 0, 94, 0.06);
+  --border-color: #e2d0f0;
+  --border-strong: #9585a8;
+  --border-style: 1px solid var(--border-color);
+
+  /* content */
+  --text-color: #1a0e2e;
+  --text-light: #6b5b85;
+  --text-disabled: #7e7095;
+  --button-text-color: #ffffff;
+
+  /* brand */
+  --primary-color: #c2005e;
+  --primary-dark: #99004a;
+  --secondary-color: #006b85;
+  --accent-color: #6d28d9;
+
+  /* status */
+  --success-color: #0f6b4f;
+  --success-text: #0f6b4f;
+  --success-bg: #e2f2ec;
+  --error-color: #b3123c;
+  --error-text: #b3123c;
+  --error-bg: #fbe4ea;
+  --error-hover-color: #8e0d30;
+  --disabled-color: #ebe0f4;
+
+  /* alpha */
+  --primary-transparent-10: rgba(194, 0, 94, 0.1);
+  --primary-transparent-15: rgba(194, 0, 94, 0.15);
+  --primary-transparent-20: rgba(194, 0, 94, 0.2);
+  --primary-transparent-30: rgba(194, 0, 94, 0.3);
+  --secondary-transparent-10: rgba(0, 107, 133, 0.1);
+  --secondary-transparent-50: rgba(0, 107, 133, 0.5);
+  --accent-transparent-10: rgba(109, 40, 217, 0.1);
+  --accent-transparent-50: rgba(109, 40, 217, 0.5);
+  --card-bg-transparent-30: rgba(255, 255, 255, 0.3);
+  --card-bg-transparent-50: rgba(255, 255, 255, 0.5);
+  --card-bg-transparent-80: rgba(255, 255, 255, 0.8);
+  --text-light-transparent-20: rgba(107, 91, 133, 0.2);
+  --text-light-transparent-30: rgba(107, 91, 133, 0.3);
+  --error-bg-transparent-10: rgba(179, 18, 60, 0.1);
+  --card-shadow: rgba(26, 14, 46, 0.16);
+  --spinner-bg: rgba(107, 91, 133, 0.15);
+
+  /* gradients */
+  --gradient-brand: linear-gradient(90deg, #c2005e, #6d28d9);
+  --gradient-rule: linear-gradient(90deg, #c2005e, #006b85);
+
+  /* shape & elevation */
+  --shadow-sm: 0 1px 0 var(--card-shadow);
+  --shadow-md: 0 4px 16px var(--card-shadow);
+  --shadow-lg: 0 16px 48px var(--card-shadow);
+  --shadow: var(--shadow-md);
+  --focus-ring: 0 0 0 3px var(--primary-transparent-30);
+
+  /* decoration (opt-in) */
+  --decor-glow: 3px 3px 0 var(--accent-color);
+  --decor-sheen: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.35) 0%,
+    transparent 40%
+  );
+  --decor-overlay: radial-gradient(
+    circle,
+    rgba(26, 14, 46, 0.5) 0.5px,
+    transparent 0.5px
+  );
+  --decor-gradient: linear-gradient(
+    180deg,
+    transparent 70%,
+    var(--primary-transparent-10) 100%
+  );
+}
+```
+
+Font, type-scale, spacing, radius and motion tokens are inherited from `:root` — they are
+mode-independent and are not redeclared here.
+
+## Preview
+
+```
+┌────────────────────────────────────────────────┐
+│████████████████████████████████████████████████│ ← 3px magenta→cyan gradient
+│  リスト                                          │ ← kana, 9px #006B85, +0.4em
+│  D E S I G N   F O L K S                        │ ← Chakra Petch 700 21.3px
+│                                                 │   uppercase, +0.12em #1A0E2E
+│  42 members · updated 3d ago                    │ ← Plex Mono 12px #6B5B85
+│                                                 │
+│  ┏━━━━━━━━━━━┓                                   │
+│  ┃   VIEW    ┃▟  ← 3px offset shadow #6D28D9    │
+│  ┗━━━━━━━━━━━┛▟                                  │
+└────────────────────────────────────────────────┘
+   card #FFFFFF on page #F6F0FA, 1px #E2D0F0, r0
+```
+
+Swatches — `#F6F0FA` `#FFFFFF` `#E2D0F0` `#9585A8` `#6B5B85` `#1A0E2E` · `#C2005E` `#99004A`
+`#006B85` `#6D28D9` · `#0F6B4F` `#B3123C`
+
+## Migration notes
+
+Same structural work as the dark variant.
+
+- `app.css` — `body` moves to `--font-body`; add font preloads. With decoration on, `body`
+  needs an `::after` halftone layer and a fixed grid-horizon background.
+- `app-header.css` — the bottom border becomes a gradient, so `border-bottom` must be replaced
+  with a `::after` bar (gradients cannot be used as `border-color`). **This is a real CSS
+  change, not just a token swap.**
+- `data-card.css` — `.data-card::before` only needs `background-color` →
+  `background-image: var(--gradient-rule)`.
+- `action-buttons.css` — `border-radius: 0` already matches. Primary buttons need a gradient
+  `background-image`, a `::after` sheen gated on `[data-decor='on']`, and the offset-shadow
+  hover/press pair.
+- `data-display.css`, `dashboard.css` — the larger `--space-*` scale changes list density
+  noticeably; these two carry the most hard-coded padding.
+- **Markup change required:** the gradient rules on `AppHeader` and the modal need a
+  pseudo-element that does not exist yet.
+- **Watch out:** the offset-shadow press interaction moves the button by 2px. Verify it does
+  not cause layout shift inside `ButtonsPanel`'s flex column — it should not, since `transform`
+  does not affect layout, but the shadow does extend the visual bounding box.

--- a/docs/themes/theme-c-bayside-neon.html
+++ b/docs/themes/theme-c-bayside-neon.html
@@ -1,0 +1,978 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Theme C — Bayside Neon 湾岸ネオン · Bluelist</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@700&family=IBM+Plex+Mono&family=Inter:wght@400;500;600&family=Zen+Kaku+Gothic+New:wght@500&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* ─── THEME TOKENS — dark (:root) ─────────────────────────────── */
+      :root {
+        --font-display: 'Chakra Petch', system-ui, sans-serif;
+        --font-body: 'Inter', system-ui, -apple-system, sans-serif;
+        --font-mono: 'IBM Plex Mono', ui-monospace, monospace;
+        --font-kana: 'Zen Kaku Gothic New', var(--font-body);
+
+        --text-xs: 0.563rem;
+        --text-sm: 0.75rem;
+        --text-base: 1rem;
+        --text-lg: 1.333rem;
+        --text-xl: 1.777rem;
+        --text-2xl: 2.369rem;
+        --text-3xl: 3.157rem;
+        --leading-tight: 1.1;
+        --leading-relaxed: 1.6;
+        --tracking-wide: 0.12em;
+        --tracking-wider: 0.4em;
+
+        --background-color: #0a0614;
+        --card-color: #150e24;
+        --card-bg: var(--card-color);
+        --surface-raised: #1e1433;
+        --input-bg: #07040f;
+        --hover-bg: rgba(255, 77, 166, 0.1);
+        --border-color: #3a2260;
+        --border-strong: #7a63a3;
+        --border-style: 1px solid var(--border-color);
+
+        --text-color: #f2e9ff;
+        --text-light: #a896c9;
+        --text-disabled: #7b6c99;
+        --button-text-color: #0a0614;
+
+        --primary-color: #ff4da6;
+        --primary-dark: #e8479a;
+        --secondary-color: #35e8ff;
+        --accent-color: #b96bff;
+
+        --success-color: #3de8b0;
+        --success-text: #3de8b0;
+        --success-bg: rgba(61, 232, 176, 0.12);
+        --error-color: #ff5c7a;
+        --error-text: #ff5c7a;
+        --error-bg: rgba(255, 92, 122, 0.12);
+        --error-hover-color: #ff7d94;
+        --disabled-color: #2a1b45;
+
+        --primary-transparent-10: rgba(255, 77, 166, 0.1);
+        --primary-transparent-20: rgba(255, 77, 166, 0.2);
+        --primary-transparent-30: rgba(255, 77, 166, 0.3);
+        --card-bg-transparent-80: rgba(21, 14, 36, 0.8);
+        --card-shadow: rgba(0, 0, 0, 0.6);
+
+        --gradient-brand: linear-gradient(90deg, #ff4da6, #b96bff);
+        --gradient-rule: linear-gradient(90deg, #ff4da6, #35e8ff);
+
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 16px;
+        --space-4: 24px;
+        --space-5: 32px;
+        --space-6: 40px;
+        --space-7: 56px;
+        --space-8: 80px;
+        --card-padding: var(--space-4);
+        --content-max-width: 1240px;
+
+        --radius-sm: 0;
+        --radius-md: 0;
+        --shadow-sm: 0 1px 0 var(--card-shadow);
+        --shadow-md: 0 4px 16px var(--card-shadow);
+        --shadow-lg: 0 16px 48px var(--card-shadow);
+        --focus-ring: 0 0 0 3px var(--primary-transparent-30);
+
+        --duration-base: 140ms;
+        --ease: cubic-bezier(0.16, 1, 0.3, 1);
+        --transition: all var(--duration-base) var(--ease);
+
+        --decor-glow: 0 0 12px var(--primary-transparent-30);
+        --decor-sheen: linear-gradient(
+          180deg,
+          rgba(255, 255, 255, 0.22) 0%,
+          transparent 40%
+        );
+        --decor-overlay: repeating-linear-gradient(
+          180deg,
+          rgba(0, 0, 0, 0.14) 0 1px,
+          transparent 1px 3px
+        );
+        --overlay-blend: normal;
+        --overlay-opacity: 1;
+      }
+
+      /* ─── THEME TOKENS — light ────────────────────────────────────── */
+      .light-theme {
+        --background-color: #f6f0fa;
+        --card-color: #ffffff;
+        --surface-raised: #ffffff;
+        --input-bg: #ffffff;
+        --hover-bg: rgba(194, 0, 94, 0.06);
+        --border-color: #e2d0f0;
+        --border-strong: #9585a8;
+
+        --text-color: #1a0e2e;
+        --text-light: #6b5b85;
+        --text-disabled: #7e7095;
+        --button-text-color: #ffffff;
+
+        --primary-color: #c2005e;
+        --primary-dark: #99004a;
+        --secondary-color: #006b85;
+        --accent-color: #6d28d9;
+
+        --success-color: #0f6b4f;
+        --success-text: #0f6b4f;
+        --success-bg: #e2f2ec;
+        --error-color: #b3123c;
+        --error-text: #b3123c;
+        --error-bg: #fbe4ea;
+        --error-hover-color: #8e0d30;
+        --disabled-color: #ebe0f4;
+
+        --primary-transparent-10: rgba(194, 0, 94, 0.1);
+        --primary-transparent-20: rgba(194, 0, 94, 0.2);
+        --primary-transparent-30: rgba(194, 0, 94, 0.3);
+        --card-bg-transparent-80: rgba(255, 255, 255, 0.8);
+        --card-shadow: rgba(26, 14, 46, 0.16);
+
+        --gradient-brand: linear-gradient(90deg, #c2005e, #6d28d9);
+        --gradient-rule: linear-gradient(90deg, #c2005e, #006b85);
+
+        /* chrome replaces glow on a light ground */
+        --decor-glow: 3px 3px 0 var(--accent-color);
+        --decor-sheen: linear-gradient(
+          180deg,
+          rgba(255, 255, 255, 0.35) 0%,
+          transparent 40%
+        );
+        --decor-overlay: radial-gradient(
+          circle,
+          rgba(26, 14, 46, 1) 0.5px,
+          transparent 0.5px
+        );
+        --overlay-blend: multiply;
+        --overlay-opacity: 0.06;
+      }
+
+      /* ─── PREVIEW CHROME ──────────────────────────────────────────── */
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family: var(--font-body);
+        background: var(--background-color);
+        color: var(--text-color);
+        line-height: var(--leading-relaxed);
+        transition: background-color var(--duration-base) var(--ease),
+          color var(--duration-base) var(--ease);
+      }
+      html[data-decor='on'] body::after {
+        content: '';
+        position: fixed;
+        inset: 0;
+        pointer-events: none;
+        z-index: 9998;
+        background-image: var(--decor-overlay);
+        background-size: auto, 4px 4px;
+        mix-blend-mode: var(--overlay-blend);
+        opacity: var(--overlay-opacity);
+      }
+      html[data-decor='on'] body::before {
+        content: '';
+        position: fixed;
+        inset: 70% 0 0 0;
+        pointer-events: none;
+        z-index: 0;
+        background-image: linear-gradient(
+            var(--primary-transparent-10) 1px,
+            transparent 1px
+          ),
+          linear-gradient(
+            90deg,
+            var(--primary-transparent-10) 1px,
+            transparent 1px
+          );
+        background-size: 40px 40px;
+        transform: perspective(300px) rotateX(60deg);
+        transform-origin: bottom;
+      }
+      html[data-decor='on'] .btn--primary,
+      html[data-decor='on'] .chip:hover,
+      html[data-decor='on'] .card:hover {
+        box-shadow: var(--decor-glow);
+      }
+      html[data-decor='on'] .btn--primary::after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background: var(--decor-sheen);
+        pointer-events: none;
+      }
+
+      .wrap {
+        max-width: var(--content-max-width);
+        margin: 0 auto;
+        padding: var(--space-5);
+        position: relative;
+        z-index: 1;
+      }
+      .bar {
+        position: sticky;
+        top: 0;
+        z-index: 9999;
+        display: flex;
+        gap: var(--space-3);
+        align-items: center;
+        flex-wrap: wrap;
+        padding: var(--space-3) var(--space-5);
+        background: var(--background-color);
+        position: sticky;
+      }
+      .bar::after {
+        content: '';
+        position: absolute;
+        inset: auto 0 0 0;
+        height: 2px;
+        background-image: var(--gradient-rule);
+      }
+      .bar__title {
+        font-family: var(--font-display);
+        font-weight: 700;
+        font-size: var(--text-lg);
+        text-transform: uppercase;
+        letter-spacing: var(--tracking-wide);
+        color: var(--primary-color);
+        margin-right: auto;
+      }
+      .bar__tag {
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        color: var(--secondary-color);
+        border: 1px solid var(--border-color);
+        padding: 2px 8px;
+      }
+
+      h2.sec {
+        font-family: var(--font-display);
+        font-weight: 700;
+        font-size: var(--text-2xl);
+        line-height: var(--leading-tight);
+        text-transform: uppercase;
+        letter-spacing: var(--tracking-wide);
+        margin: var(--space-8) 0 var(--space-2);
+      }
+      h2.sec:first-of-type {
+        margin-top: var(--space-4);
+      }
+      .kana {
+        font-family: var(--font-kana);
+        font-weight: 500;
+        font-size: var(--text-xs);
+        letter-spacing: var(--tracking-wider);
+        color: var(--secondary-color);
+        display: block;
+        text-transform: none;
+      }
+      .lede {
+        color: var(--text-light);
+        max-width: 62ch;
+        margin-bottom: var(--space-4);
+      }
+      .rule {
+        height: 3px;
+        background-image: var(--gradient-rule);
+        margin-bottom: var(--space-4);
+      }
+
+      .sw-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
+        gap: var(--space-2);
+      }
+      .sw {
+        border: var(--border-style);
+      }
+      .sw__chip {
+        height: 76px;
+      }
+      .sw__meta {
+        padding: var(--space-2);
+        background: var(--card-color);
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        line-height: 1.7;
+      }
+      .sw__hex {
+        color: var(--text-light);
+        text-transform: uppercase;
+      }
+      .sw__ratio {
+        color: var(--success-text);
+      }
+
+      .spec > * {
+        margin-bottom: var(--space-3);
+      }
+      .spec .s3,
+      .spec .s2,
+      .spec .s1,
+      .spec .s0 {
+        font-family: var(--font-display);
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: var(--tracking-wide);
+        line-height: var(--leading-tight);
+      }
+      .spec .s3 {
+        font-size: var(--text-3xl);
+      }
+      .spec .s2 {
+        font-size: var(--text-2xl);
+      }
+      .spec .s1 {
+        font-size: var(--text-xl);
+      }
+      .spec .s0 {
+        font-size: var(--text-lg);
+      }
+      .spec .body {
+        font-size: var(--text-base);
+        max-width: 62ch;
+      }
+      .spec .meta {
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        color: var(--text-light);
+      }
+
+      .btn-row {
+        display: flex;
+        gap: var(--space-3);
+        flex-wrap: wrap;
+        align-items: center;
+      }
+      .btn {
+        position: relative;
+        font-family: var(--font-body);
+        font-size: 0.95rem;
+        font-weight: 500;
+        border: none;
+        border-radius: 0;
+        padding: 12px 22px;
+        cursor: pointer;
+        transition: var(--transition);
+      }
+      .btn:active {
+        transform: translateY(2px);
+      }
+      .btn:focus-visible {
+        outline: none;
+        box-shadow: var(--focus-ring);
+      }
+      .btn--primary {
+        background-image: var(--gradient-brand);
+        color: var(--button-text-color);
+      }
+      .btn--primary:hover {
+        filter: brightness(1.12);
+      }
+      .btn--secondary {
+        background: var(--primary-transparent-10);
+        border: 1px solid var(--primary-color);
+        color: var(--primary-color);
+      }
+      .btn--secondary:hover {
+        background: var(--primary-transparent-20);
+      }
+      .btn--ghost {
+        background: transparent;
+        border: 1px solid var(--border-strong);
+        color: var(--text-color);
+      }
+      .btn--ghost:hover {
+        background: var(--hover-bg);
+      }
+      .btn--danger {
+        background: var(--error-color);
+        color: var(--button-text-color);
+      }
+      .btn--danger:hover {
+        background: var(--error-hover-color);
+      }
+      .btn--disabled {
+        background: var(--disabled-color);
+        color: var(--text-disabled);
+        cursor: not-allowed;
+      }
+      .btn--icon {
+        background: transparent;
+        color: var(--text-light);
+        padding: 8px;
+        font-size: 1.1rem;
+        line-height: 1;
+      }
+      .btn--icon:hover {
+        background: var(--hover-bg);
+        color: var(--secondary-color);
+      }
+
+      .mock {
+        border: var(--border-style);
+        box-shadow: var(--shadow-md);
+      }
+      .mock__header {
+        position: relative;
+        display: flex;
+        align-items: center;
+        gap: var(--space-3);
+        padding: var(--space-3) var(--space-4);
+        background: var(--background-color);
+      }
+      .mock__header::after {
+        content: '';
+        position: absolute;
+        inset: auto 0 0 0;
+        height: 2px;
+        background-image: var(--gradient-rule);
+      }
+      .mock__logo {
+        font-family: var(--font-display);
+        font-weight: 700;
+        font-size: var(--text-xl);
+        text-transform: uppercase;
+        letter-spacing: var(--tracking-wide);
+        color: var(--primary-color);
+        margin-right: auto;
+      }
+      .mock__status {
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        color: var(--text-light);
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .dot {
+        width: 8px;
+        height: 8px;
+        background: var(--success-color);
+      }
+      .mock__body {
+        padding: var(--space-4);
+        background: var(--background-color);
+        display: grid;
+        grid-template-columns: 220px 1fr;
+        gap: var(--space-4);
+      }
+      @media (max-width: 820px) {
+        .mock__body {
+          grid-template-columns: 1fr;
+        }
+      }
+      .panel {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+      }
+
+      .card {
+        position: relative;
+        background: var(--card-color);
+        border: var(--border-style);
+        box-shadow: var(--shadow-sm);
+        padding: var(--card-padding);
+        margin-bottom: var(--space-3);
+        transition: var(--transition);
+      }
+      .card::before {
+        content: '';
+        position: absolute;
+        inset: 0 0 auto 0;
+        height: 3px;
+        background-image: var(--gradient-rule);
+      }
+      .card:hover {
+        border-color: var(--primary-color);
+      }
+      .card__title {
+        font-family: var(--font-display);
+        font-weight: 700;
+        font-size: var(--text-lg);
+        text-transform: uppercase;
+        letter-spacing: var(--tracking-wide);
+        line-height: var(--leading-tight);
+      }
+      .card__meta {
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        color: var(--text-light);
+        margin: var(--space-1) 0 var(--space-3);
+      }
+
+      .member {
+        display: flex;
+        align-items: center;
+        gap: var(--space-3);
+        background: var(--card-color);
+        border-left: 2px solid var(--border-color);
+        padding: var(--space-2) var(--space-3);
+        margin-bottom: var(--space-2);
+        transition: var(--transition);
+      }
+      .member:hover {
+        border-left-color: var(--secondary-color);
+        background: var(--hover-bg);
+      }
+      .avatar {
+        width: 34px;
+        height: 34px;
+        background: var(--primary-transparent-20);
+        border: 1px solid var(--primary-color);
+        flex: none;
+      }
+      .member__name {
+        font-weight: 500;
+      }
+      .member__handle {
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        color: var(--text-light);
+      }
+
+      .chips {
+        display: flex;
+        gap: var(--space-2);
+        flex-wrap: wrap;
+        margin-top: var(--space-3);
+      }
+      .chip {
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        background: var(--primary-transparent-10);
+        border: 1px solid var(--primary-color);
+        color: var(--primary-color);
+        padding: 4px 10px;
+        cursor: pointer;
+        transition: var(--transition);
+      }
+      .chip:hover {
+        background: var(--primary-transparent-20);
+      }
+      .chip--off {
+        background: var(--disabled-color);
+        border-color: var(--disabled-color);
+        color: var(--text-disabled);
+      }
+
+      .pager {
+        display: flex;
+        align-items: center;
+        gap: var(--space-3);
+        border-top: var(--border-style);
+        padding-top: var(--space-3);
+        margin-top: var(--space-3);
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        color: var(--text-light);
+      }
+      .pager button {
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        background: var(--primary-transparent-10);
+        border: 1px solid var(--primary-color);
+        color: var(--primary-color);
+        padding: 4px 12px;
+        cursor: pointer;
+      }
+
+      .field {
+        display: block;
+        margin-bottom: var(--space-3);
+      }
+      .field label {
+        display: block;
+        font-size: var(--text-sm);
+        color: var(--text-light);
+        margin-bottom: 6px;
+      }
+      .field input {
+        width: 100%;
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        background: var(--input-bg);
+        border: 1px solid var(--border-strong);
+        border-radius: 0;
+        color: var(--text-color);
+        padding: 10px 12px;
+        transition: var(--transition);
+      }
+      .field input:focus {
+        outline: none;
+        border-color: var(--secondary-color);
+        box-shadow: var(--focus-ring);
+      }
+
+      .note {
+        padding: var(--space-3);
+        margin-bottom: var(--space-2);
+        font-size: var(--text-sm);
+      }
+      .note--ok {
+        background: var(--success-bg);
+        color: var(--success-text);
+        border-left: 3px solid var(--success-text);
+      }
+      .note--err {
+        background: var(--error-bg);
+        color: var(--error-text);
+        border-left: 3px solid var(--error-text);
+      }
+      .empty {
+        border: 1px dashed var(--border-strong);
+        padding: var(--space-5);
+        text-align: center;
+        color: var(--text-light);
+      }
+
+      .cols {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-4);
+      }
+      @media (max-width: 820px) {
+        .cols {
+          grid-template-columns: 1fr;
+        }
+      }
+      .scale-row {
+        display: flex;
+        align-items: center;
+        gap: var(--space-3);
+        margin-bottom: 6px;
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        color: var(--text-light);
+      }
+      .scale-bar {
+        height: 14px;
+        background: var(--primary-transparent-30);
+        border-left: 2px solid var(--primary-color);
+      }
+
+      table.tk {
+        width: 100%;
+        border-collapse: collapse;
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+      }
+      table.tk th,
+      table.tk td {
+        text-align: left;
+        padding: 8px 10px;
+        border-bottom: var(--border-style);
+      }
+      table.tk th {
+        color: var(--text-light);
+        font-weight: 400;
+      }
+      .ok {
+        color: var(--success-text);
+      }
+
+      .warn {
+        border-left: 3px solid var(--accent-color);
+        background: var(--primary-transparent-10);
+        padding: var(--space-3);
+        margin-bottom: var(--space-4);
+        font-size: var(--text-base);
+        max-width: 70ch;
+      }
+
+      footer.f {
+        margin-top: var(--space-8);
+        padding-top: var(--space-4);
+        border-top: var(--border-style);
+        color: var(--text-light);
+        font-size: var(--text-sm);
+      }
+      footer.f a {
+        color: var(--primary-color);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="bar">
+      <div class="bar__title">Theme C — Bayside Neon 湾岸ネオン</div>
+      <span class="bar__tag">maximalist</span>
+      <button class="btn btn--secondary" id="mode">◐ Light mode</button>
+      <button class="btn btn--ghost" id="decor">Decoration: off</button>
+    </div>
+
+    <div class="wrap">
+      <h2 class="sec"><span class="kana">わんがんネオン</span>Overview</h2>
+      <div class="rule"></div>
+      <p class="lede">
+        The Tokyo bayfront at 2am — ink-violet black, magenta signage, cyan
+        cutting through. In light mode it inverts to the mall at midday: chrome,
+        glass and lilac-white tile, with hard offset shadows replacing the glow.
+      </p>
+      <div class="warn">
+        <strong>Risk note.</strong> This is the loud one. It is the most likely
+        to read as pastiche and the most likely to fatigue on the dense,
+        repeating surfaces Bluelist is mostly made of. Saturated colour is kept
+        to chrome, headings and accents; body rows stay on
+        <code>--text-color</code>. Try the decoration toggle both ways — that is
+        the real decision here.
+      </div>
+
+      <h2 class="sec"><span class="kana">カラー</span>Palette</h2>
+      <div class="rule"></div>
+      <p class="lede">
+        Every value is checked against both the page and the card background;
+        the figure shown is the lower of the two.
+      </p>
+      <div class="sw-grid" id="swatches"></div>
+
+      <h2 class="sec"><span class="kana">タイポグラフィ</span>Typography</h2>
+      <div class="rule"></div>
+      <p class="lede">
+        Chakra Petch 700 uppercase with 0.12em tracking for headings, Inter for
+        body, IBM Plex Mono for data. Scale ratio 1.333 — poster-like. The
+        vaporwave fullwidth convention (ＡＥＳＴＨＥＴＩＣ) is deliberately not
+        used; it breaks screen readers and text selection, so wide tracking does
+        the same job safely.
+      </p>
+      <div class="spec">
+        <div class="s3">Organise your follows</div>
+        <div class="s2">Design Folks</div>
+        <div class="s1">42 members</div>
+        <div class="s0">Suggested lists</div>
+        <p class="body">
+          Body copy is Inter at 16px with a 1.6 line height, deliberately plain.
+          All of the theme's personality is carried above this line — the moment
+          display styling reaches body copy in a list-heavy app, readability
+          goes.
+        </p>
+        <div class="meta">@samuel.bsky.social · did:plc:7f3k… · 3d ago</div>
+      </div>
+
+      <h2 class="sec"><span class="kana">ボタン</span>Buttons</h2>
+      <div class="rule"></div>
+      <p class="lede">
+        Zero radius. Primary is a magenta→violet gradient. With decoration on it
+        gains a glow (dark) or a hard chrome offset (light).
+      </p>
+      <div class="btn-row">
+        <button class="btn btn--primary">View list</button>
+        <button class="btn btn--secondary">Curate with AI</button>
+        <button class="btn btn--ghost">Cancel</button>
+        <button class="btn btn--danger">Delete list</button>
+        <button class="btn btn--disabled" disabled>Unavailable</button>
+        <button class="btn btn--icon" title="Edit">✎</button>
+        <button class="btn btn--icon" title="Delete">🗑</button>
+      </div>
+
+      <h2 class="sec"><span class="kana">インターフェース</span>Interface</h2>
+      <div class="rule"></div>
+      <p class="lede">
+        Note the gradient rules on the header and cards — these cannot be done
+        with <code>border-color</code>, so they need pseudo-elements. That is
+        the real CSS cost of this family.
+      </p>
+      <div class="mock">
+        <div class="mock__header">
+          <div class="mock__logo">bluelist</div>
+          <div class="mock__status">
+            <span class="dot"></span>@samuel.bsky.social
+          </div>
+          <button class="btn btn--icon" title="Toggle theme">☾</button>
+        </div>
+        <div class="mock__body">
+          <div class="panel">
+            <button class="btn btn--secondary">Get timeline</button>
+            <button class="btn btn--secondary">Get follows</button>
+            <button class="btn btn--secondary">Get lists</button>
+            <button class="btn btn--primary">Curate</button>
+          </div>
+          <div>
+            <div class="card">
+              <div class="card__title">Design Folks</div>
+              <div class="card__meta">42 members · updated 3d ago</div>
+              <div class="member">
+                <div class="avatar"></div>
+                <div>
+                  <div class="member__name">Mariya Takeuchi</div>
+                  <div class="member__handle">@mariya.bsky.social</div>
+                </div>
+              </div>
+              <div class="member">
+                <div class="avatar"></div>
+                <div>
+                  <div class="member__name">Tatsuro Yamashita</div>
+                  <div class="member__handle">@tatsuro.bsky.social</div>
+                </div>
+              </div>
+              <div class="chips">
+                <span class="chip">Design Folks</span>
+                <span class="chip">Music</span>
+                <span class="chip chip--off">Archived</span>
+              </div>
+              <div class="pager">
+                <button>‹ Prev</button>
+                <span>Page 2 of 7</span>
+                <button>Next ›</button>
+              </div>
+            </div>
+            <div class="note note--ok">Added 3 users to “Design Folks”.</div>
+            <div class="note note--err">
+              Token has expired — please sign in again.
+            </div>
+            <div class="empty">No lists yet. Create one to get started.</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="cols">
+        <div>
+          <h2 class="sec"><span class="kana">フォーム</span>Form</h2>
+          <div class="rule"></div>
+          <div class="field">
+            <label>List name</label>
+            <input value="Design Folks" />
+          </div>
+          <div class="field">
+            <label>Description</label>
+            <input placeholder="Focus this input to see the ring" />
+          </div>
+          <div class="btn-row">
+            <button class="btn btn--primary">Save</button>
+            <button class="btn btn--ghost">Cancel</button>
+          </div>
+        </div>
+        <div>
+          <h2 class="sec"><span class="kana">スペース</span>Spacing</h2>
+          <div class="rule"></div>
+          <div id="scale"></div>
+          <p class="lede" style="margin-top: var(--space-3)">
+            8px base unit — the largest of the three. Card padding 24px, section
+            gap 56px, content width 1240px. Rows sit tight against wide gutters.
+          </p>
+        </div>
+      </div>
+
+      <h2 class="sec"><span class="kana">コントラスト</span>Contrast record</h2>
+      <div class="rule"></div>
+      <table class="tk" id="contrast"></table>
+
+      <footer class="f">
+        Full specification:
+        <a href="theme-c-bayside-neon-dark.md">dark</a> ·
+        <a href="theme-c-bayside-neon-light.md">light</a> ·
+        <a href="index.html">compare all three families</a><br />
+        Fonts load from Google Fonts in this preview only; production is
+        self-hosted WOFF2, subset, <code>font-display: swap</code>.
+      </footer>
+    </div>
+
+    <script>
+      const SW = {
+        dark: [
+          ['--background-color', '#0A0614', 'page · ink violet', ''],
+          ['--card-color', '#150E24', 'card', ''],
+          ['--surface-raised', '#1E1433', 'modal', ''],
+          ['--border-color', '#3A2260', 'separator', ''],
+          ['--border-strong', '#7A63A3', 'control border', '3.70'],
+          ['--text-disabled', '#7B6C99', 'inactive', '3.97'],
+          ['--text-light', '#A896C9', 'metadata', '7.03'],
+          ['--text-color', '#F2E9FF', 'body', '15.96'],
+          ['--primary-color', '#FF4DA6', 'neon magenta · interactive', '6.13'],
+          ['--primary-dark', '#E8479A', 'pressed (brightens)', '5.18'],
+          ['--secondary-color', '#35E8FF', 'neon cyan · counterpoint', '12.62'],
+          ['--accent-color', '#B96BFF', 'violet · highlight', '5.90'],
+          ['--success-color', '#3DE8B0', 'success', '11.93'],
+          ['--error-color', '#FF5C7A', 'error', '6.31'],
+        ],
+        light: [
+          ['--background-color', '#F6F0FA', 'page · lilac-white', ''],
+          ['--card-color', '#FFFFFF', 'card · chrome white', ''],
+          ['--surface-raised', '#FFFFFF', 'modal', ''],
+          ['--border-color', '#E2D0F0', 'separator', ''],
+          ['--border-strong', '#9585A8', 'control border', '3.03'],
+          ['--text-disabled', '#7E7095', 'inactive', '4.04'],
+          ['--text-light', '#6B5B85', 'metadata', '5.42'],
+          ['--text-color', '#1A0E2E', 'body', '16.37'],
+          ['--primary-color', '#C2005E', 'ink magenta · interactive', '5.43'],
+          ['--primary-dark', '#99004A', 'pressed', '7.65'],
+          ['--secondary-color', '#006B85', 'deep cyan · counterpoint', '5.45'],
+          ['--accent-color', '#6D28D9', 'violet · highlight', '6.35'],
+          ['--success-color', '#0F6B4F', 'success', '5.80'],
+          ['--error-color', '#B3123C', 'error', '6.11'],
+        ],
+      };
+
+      const root = document.documentElement;
+      const isLight = () => root.classList.contains('light-theme');
+
+      function render() {
+        const rows = isLight() ? SW.light : SW.dark;
+        document.getElementById('swatches').innerHTML = rows
+          .map(
+            ([t, hex, role, ratio]) => `
+        <div class="sw">
+          <div class="sw__chip" style="background:${hex}"></div>
+          <div class="sw__meta">
+            <div>${role}</div>
+            <div class="sw__hex">${hex}</div>
+            <div class="sw__ratio">${ratio ? ratio + ':1 ✓' : '&nbsp;'}</div>
+          </div>
+        </div>`
+          )
+          .join('');
+        document.getElementById('contrast').innerHTML =
+          '<tr><th>Token</th><th>Value</th><th>Role</th><th>Ratio</th></tr>' +
+          rows
+            .map(
+              ([t, hex, role, ratio]) =>
+                `<tr><td>${t}</td><td>${hex}</td><td>${role}</td><td class="ok">${
+                  ratio ? ratio + ':1' : '—'
+                }</td></tr>`
+            )
+            .join('');
+      }
+
+      document.getElementById('scale').innerHTML = [
+        4, 8, 16, 24, 32, 40, 56, 80,
+      ]
+        .map(
+          (v, i) =>
+            `<div class="scale-row"><span style="width:70px">--space-${
+              i + 1
+            }</span><div class="scale-bar" style="width:${
+              v * 2
+            }px"></div><span>${v}px</span></div>`
+        )
+        .join('');
+
+      document.getElementById('mode').onclick = (e) => {
+        root.classList.toggle('light-theme');
+        e.target.textContent = isLight() ? '◑ Dark mode' : '◐ Light mode';
+        render();
+      };
+      document.getElementById('decor').onclick = (e) => {
+        const on = root.getAttribute('data-decor') === 'on';
+        root.setAttribute('data-decor', on ? 'off' : 'on');
+        e.target.textContent =
+          'Decoration: ' + (on ? 'off' : 'on (scanlines + glow + grid)');
+      };
+
+      render();
+    </script>
+  </body>
+</html>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -18,7 +18,28 @@ function readCert(envVar: string, fallback: string): string | undefined {
 export default defineNuxtConfig({
   compatibilityDate: '2025-03-21',
   devtools: { enabled: true },
-  modules: ['@nuxt/eslint', '@nuxt/scripts', '@nuxt/test-utils', '@pinia/nuxt'],
+  modules: [
+    '@nuxt/eslint',
+    '@nuxt/fonts',
+    '@nuxt/scripts',
+    '@nuxt/test-utils',
+    '@pinia/nuxt',
+  ],
+  fonts: {
+    // Only Google is used; disabling the rest keeps builds deterministic and offline-safe.
+    providers: {
+      adobe: false,
+      bunny: false,
+      fontshare: false,
+      fontsource: false,
+    },
+    defaults: { subsets: ['latin'] },
+    families: [
+      { name: 'Outfit', provider: 'google', weights: [500, 700] },
+      { name: 'Inter', provider: 'google', weights: [400, 500, 600] },
+      { name: 'IBM Plex Mono', provider: 'google', weights: [400] },
+    ],
+  },
   typescript: {
     typeCheck: true,
   },

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "devDependencies": {
     "@commitlint/cli": "^19.8.0",
     "@commitlint/config-conventional": "^19.8.0",
+    "@nuxt/fonts": "^0.14.0",
     "eslint-config-prettier": "^10.1.1",
     "eslint-import-resolver-node": "^0.3.10",
     "husky": "^9.1.7",

--- a/src/assets/styles/_variables.css
+++ b/src/assets/styles/_variables.css
@@ -1,82 +1,198 @@
 :root {
-  --primary-color: #a0d6ff;
-  --primary-dark: #0063c1;
-  --primary-transparent-10: rgba(255, 158, 100, 0.1);
-  --primary-transparent-20: rgba(255, 158, 100, 0.2);
-  --primary-transparent-30: rgba(255, 158, 100, 0.3);
+  /* fonts */
+  --font-display: 'Outfit', system-ui, sans-serif;
+  --font-body: 'Inter', system-ui, -apple-system, sans-serif;
+  --font-mono: 'IBM Plex Mono', ui-monospace, monospace;
 
-  --secondary-color: #f2994a;
-  --secondary-transparent-10: rgba(242, 153, 74, 0.1);
-  --secondary-transparent-50: rgba(242, 153, 74, 0.5);
+  /* type scale — 1.250 major third */
+  --text-xs: 0.64rem;
+  --text-sm: 0.8rem;
+  --text-base: 1rem;
+  --text-lg: 1.25rem;
+  --text-xl: 1.563rem;
+  --text-2xl: 1.953rem;
+  --text-3xl: 2.441rem;
+  --leading-tight: 1.2;
+  --leading-normal: 1.5;
+  --leading-relaxed: 1.6;
+  --tracking-normal: 0;
+  --tracking-wide: 0.06em;
+  --weight-normal: 400;
+  --weight-medium: 500;
+  --weight-bold: 700;
 
-  --accent-color: rgb(38, 206, 192);
-  --accent-transparent-10: rgba(38, 206, 192, 0.1);
-  --accent-transparent-50: rgba(38, 206, 192, 0.5);
-
-  --disabled-color: #4a4a4a;
-
-  --success-color: #00ba7c;
-  --error-color: #c62828;
-
-  --background-color: #16181c;
-  --border-color: #393e47;
-  --border-radius: 10px;
+  /* surfaces */
+  --background-color: #0e1b2a;
+  --card-color: #16283c;
+  --card-bg: var(--card-color);
+  --surface-raised: #1e344c;
+  --input-bg: #0a1522;
+  --hover-bg: rgba(69, 208, 224, 0.08);
+  --border-color: #2a4767;
+  --border-strong: #5f7c99;
   --border-style: 1px solid var(--border-color);
-  --shadow: 0 4px 6px var(--card-shadow);
 
-  --spinner-bg: rgba(169, 177, 214, 0.1);
+  /* content */
+  --text-color: #e6f1f7;
+  --text-light: #93afc6;
+  --text-disabled: #6d8aa1;
+  --button-text-color: #0e1b2a;
 
-  --card-color: #21242b;
-  --card-bg-transparent-50: rgba(36, 40, 59, 0.5);
-  --card-bg-transparent-80: rgba(26, 27, 38, 0.8);
-  --card-shadow: rgba(0, 0, 0, 0.3);
+  /* brand */
+  --primary-color: #45d0e0;
+  --primary-dark: #2aa7b6;
+  --secondary-color: #ff8a6b;
+  --accent-color: #ffd166;
 
-  --text-color: #e0e4e8;
-  --text-light: #8899a6;
-  --text-light-transparent-20: rgba(86, 95, 137, 0.2);
-  --text-light-transparent-30: rgba(86, 95, 137, 0.3);
-  --text-disabled: #919191;
+  /* status */
+  --success-color: #4fd1a0;
+  --success-text: #4fd1a0;
+  --success-bg: rgba(79, 209, 160, 0.12);
+  --error-color: #ff6b6b;
+  --error-text: #ff6b6b;
+  --error-bg: rgba(255, 107, 107, 0.12);
+  --error-hover-color: #e04e4e;
+  --primary-hover-color: var(--primary-dark);
+  --secondary-hover-color: #e5734f;
+  --disabled-color: #2a4767;
 
-  --transition: all 0.3s ease;
-  --font-mono: 'Courier New', Courier, monospace;
+  /* alpha — derived from their own base colour */
+  --primary-transparent-10: rgba(69, 208, 224, 0.1);
+  --primary-transparent-15: rgba(69, 208, 224, 0.15);
+  --primary-transparent-20: rgba(69, 208, 224, 0.2);
+  --primary-transparent-30: rgba(69, 208, 224, 0.3);
+  --secondary-transparent-10: rgba(255, 138, 107, 0.1);
+  --secondary-transparent-50: rgba(255, 138, 107, 0.5);
+  --accent-transparent-10: rgba(255, 209, 102, 0.1);
+  --accent-transparent-50: rgba(255, 209, 102, 0.5);
+  --card-bg-transparent-30: rgba(22, 40, 60, 0.3);
+  --card-bg-transparent-50: rgba(22, 40, 60, 0.5);
+  --card-bg-transparent-80: rgba(22, 40, 60, 0.8);
+  --text-light-transparent-20: rgba(147, 175, 198, 0.2);
+  --text-light-transparent-30: rgba(147, 175, 198, 0.3);
+  --error-bg-transparent-10: rgba(255, 107, 107, 0.1);
+  --error-bg-transparent-20: rgba(255, 107, 107, 0.2);
+  --error-bg-transparent-30: rgba(255, 107, 107, 0.3);
+  --card-shadow: rgba(0, 10, 20, 0.45);
+  --spinner-bg: rgba(147, 175, 198, 0.15);
+
+  /* spacing */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+  --space-7: 48px;
+  --space-8: 64px;
+  --card-padding: var(--space-5);
+  --section-gap: var(--space-6);
+  --page-gutter: var(--space-6);
+  --content-max-width: 1200px;
+
+  /* shape & elevation */
+  --radius-sm: 4px;
+  --radius-md: 4px;
+  --border-radius: var(--radius-md);
+  --shadow-sm: 0 1px 2px var(--card-shadow);
+  --shadow-md: 0 4px 12px var(--card-shadow);
+  --shadow-lg: 0 12px 32px var(--card-shadow);
+  --shadow: var(--shadow-md);
+  --focus-ring: 0 0 0 3px var(--primary-transparent-30);
+
+  /* motion */
+  --duration-fast: 140ms;
+  --duration-base: 200ms;
+  --ease: cubic-bezier(0.2, 0.8, 0.2, 1);
+  --transition: all var(--duration-base) var(--ease);
+
+  /* decoration — only applied under [data-decor='on'] */
+  --decor-gradient: linear-gradient(
+    180deg,
+    #0a1522 0%,
+    #0e1b2a 55%,
+    #1a2438 100%
+  );
+  --decor-sheen: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.18) 0%,
+    transparent 45%
+  );
 }
 
 .light-theme {
-  --primary-color: #1185e0;
-  --primary-dark: #0063c1;
-  --primary-transparent-10: rgba(211, 100, 255, 0.1);
-  --primary-transparent-20: rgba(211, 100, 255, 0.2);
-  --primary-transparent-30: rgba(211, 100, 255, 0.3);
-
-  --secondary-color: #ff7700;
-  --secondary-transparent-10: rgba(92, 204, 150, 0.1);
-
-  --accent-color: #7c5cff;
-  --accent-transparent-10: rgba(187, 154, 247, 0.1);
-  --accent-transparent-50: rgba(187, 154, 247, 0.5);
-
-  --disabled-color: #e0e0e0;
-
-  --success-color: #00ba7c;
-  --success-bg: #e8f5e9;
-  --error-color: #c62828;
-  --error-bg: #ffebee;
-
-  --background-color: #f7f7f8;
-  --border-color: #e1e8ed;
-  --border-style: 1px solid var(--border-color);
-  --shadow: 0 4px 6px var(--card-shadow);
-
-  --spinner-bg: rgba(35, 36, 37, 0.4);
-
+  /* surfaces */
+  --background-color: #eaf6fa;
   --card-color: #ffffff;
-  --card-shadow: rgba(0, 0, 0, 0.1);
-  --card-bg-transparent-50: rgba(189, 190, 197, 0.5);
-  --card-bg-transparent-80: rgba(204, 206, 219, 0.8);
+  --card-bg: var(--card-color);
+  --surface-raised: #ffffff;
+  --input-bg: #ffffff;
+  --hover-bg: rgba(0, 112, 127, 0.06);
+  --border-color: #c3dee9;
+  --border-strong: #6b8998;
+  --border-style: 1px solid var(--border-color);
 
-  --text-color: #141618;
-  --text-light: #5c6c7c;
-  --text-light-transparent-20: rgba(86, 95, 137, 0.2);
-  --text-light-transparent-30: rgba(86, 95, 137, 0.3);
-  --text-disabled: #a0a0a0;
+  /* content */
+  --text-color: #0f2233;
+  --text-light: #4e6b7d;
+  --text-disabled: #6f8b9a;
+  --button-text-color: #ffffff;
+
+  /* brand — deepened for AA on a light ground */
+  --primary-color: #00707f;
+  --primary-dark: #005560;
+  --secondary-color: #c2410c;
+  --accent-color: #8a5406;
+
+  /* status */
+  --success-color: #12694f;
+  --success-text: #12694f;
+  --success-bg: #e2f1ec;
+  --error-color: #b02020;
+  --error-text: #b02020;
+  --error-bg: #fbe6e6;
+  --error-hover-color: #8c1818;
+  --primary-hover-color: var(--primary-dark);
+  --secondary-hover-color: #9a340a;
+  --disabled-color: #d8e7ee;
+
+  /* alpha — derived from their own base colour */
+  --primary-transparent-10: rgba(0, 112, 127, 0.1);
+  --primary-transparent-15: rgba(0, 112, 127, 0.15);
+  --primary-transparent-20: rgba(0, 112, 127, 0.2);
+  --primary-transparent-30: rgba(0, 112, 127, 0.3);
+  --secondary-transparent-10: rgba(194, 65, 12, 0.1);
+  --secondary-transparent-50: rgba(194, 65, 12, 0.5);
+  --accent-transparent-10: rgba(138, 84, 6, 0.1);
+  --accent-transparent-50: rgba(138, 84, 6, 0.5);
+  --card-bg-transparent-30: rgba(255, 255, 255, 0.3);
+  --card-bg-transparent-50: rgba(255, 255, 255, 0.5);
+  --card-bg-transparent-80: rgba(255, 255, 255, 0.8);
+  --text-light-transparent-20: rgba(78, 107, 125, 0.2);
+  --text-light-transparent-30: rgba(78, 107, 125, 0.3);
+  --error-bg-transparent-10: rgba(176, 32, 32, 0.1);
+  --error-bg-transparent-20: rgba(176, 32, 32, 0.2);
+  --error-bg-transparent-30: rgba(176, 32, 32, 0.3);
+  --card-shadow: rgba(15, 34, 51, 0.1);
+  --spinner-bg: rgba(78, 107, 125, 0.15);
+
+  /* shape & elevation */
+  --shadow-sm: 0 1px 2px var(--card-shadow);
+  --shadow-md: 0 4px 12px var(--card-shadow);
+  --shadow-lg: 0 12px 32px var(--card-shadow);
+  --shadow: var(--shadow-md);
+  --focus-ring: 0 0 0 3px var(--primary-transparent-30);
+
+  /* decoration — only applied under [data-decor='on'] */
+  --decor-gradient: linear-gradient(
+    180deg,
+    #d6eef7 0%,
+    #eaf6fa 45%,
+    #f7fcfd 100%
+  );
+  --decor-sheen: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.22) 0%,
+    transparent 45%
+  );
 }

--- a/src/assets/styles/action-buttons.css
+++ b/src/assets/styles/action-buttons.css
@@ -1,8 +1,8 @@
 .buttons-panel {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
-  font-family: var(--font-mono);
+  gap: var(--space-3);
+  font-family: var(--font-body);
 }
 
 .buttons-panel--disabled {
@@ -10,23 +10,21 @@
 }
 
 .action-button {
-  border: none;
-  border-radius: var(--border-radius);
-  font-weight: 500;
+  border-radius: var(--radius-sm);
+  font-weight: var(--weight-medium);
   cursor: pointer;
-  transition: var(--transition);
   font-size: 0.95rem;
   text-align: left;
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
   background-color: var(--primary-transparent-10);
-  color: var(--text-color);
-  padding: 0.75rem 1rem;
+  color: var(--primary-color);
+  padding: 11px 20px;
   display: flex;
   align-items: center;
   position: relative;
+  overflow: hidden;
   border: 1px solid var(--primary-color);
-  border-radius: 0;
-  transition: background-color 0.2s, transform 0.1s;
+  transition: var(--transition);
 }
 
 .action-button:hover {
@@ -38,13 +36,22 @@
   transform: translateY(1px);
 }
 
-.action-button:focus {
+.action-button:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 2px var(--primary-transparent-20);
+  box-shadow: var(--focus-ring);
+}
+
+/* Opt-in reflective sheen — the pool-surface lever */
+html[data-decor='on'] .action-button::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image: var(--decor-sheen);
+  pointer-events: none;
 }
 
 .action-button__icon {
-  margin-right: 0.75rem;
+  margin-right: var(--space-3);
   font-size: 1.1rem;
   width: 24px;
   height: 24px;
@@ -52,11 +59,12 @@
   align-items: center;
   justify-content: center;
   color: var(--primary-color);
-  border-radius: 0;
+  border-radius: var(--radius-sm);
 }
 
 .action-button--processing {
-  background-color: transparent;
-  color: var(--disabled-color);
+  background-color: var(--disabled-color);
+  border-color: var(--disabled-color);
+  color: var(--text-disabled);
   pointer-events: none;
 }

--- a/src/assets/styles/app-header.css
+++ b/src/assets/styles/app-header.css
@@ -1,14 +1,20 @@
 .app-header {
   display: flex;
   align-items: center;
-  padding: 1rem;
+  padding: var(--space-4);
   background-color: var(--card-color);
   border-bottom: var(--border-style);
-  box-shadow: var(--shadow);
+  box-shadow: var(--shadow-sm);
   position: fixed;
   width: 100%;
   top: 0;
   z-index: 1;
+}
+
+/* Opt-in sky wash — off unless <html data-decor="on"> */
+html[data-decor='on'] .app-header {
+  background-image: var(--decor-gradient);
+  background-attachment: fixed;
 }
 
 .app-header::before {
@@ -18,14 +24,14 @@
   left: 0;
   right: 0;
   height: 2px;
-  background-color: var(--accent-color);
+  background-color: var(--primary-color);
 }
 
 .app-header__title {
   font-size: 1.5rem;
   font-weight: 700;
   color: var(--primary-color);
-  font-family: var(--font-mono);
+  font-family: var(--font-display);
   margin: 0;
   margin-right: 1.5rem;
 }
@@ -65,7 +71,7 @@
   font-weight: 600;
   cursor: pointer;
   transition: var(--transition);
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
   position: relative;
 }
 

--- a/src/assets/styles/app.css
+++ b/src/assets/styles/app.css
@@ -7,11 +7,16 @@
 }
 
 body {
-  font-family: var(--font-mono), 'Inter', -apple-system, BlinkMacSystemFont,
-    'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+  font-family: var(--font-body);
   background-color: var(--background-color);
   color: var(--text-color);
-  line-height: 1.6;
+  line-height: var(--leading-relaxed);
+}
+
+/* Opt-in decorative layer — off unless <html data-decor="on"> */
+html[data-decor='on'] body {
+  background-image: var(--decor-gradient);
+  background-attachment: fixed;
 }
 
 .app {
@@ -23,7 +28,7 @@ body {
 .app__header {
   background-color: var(--background-color);
   color: var(--text-color);
-  padding: 1rem 2rem;
+  padding: var(--space-4) var(--space-6);
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -40,31 +45,31 @@ body {
 }
 
 .app__title {
-  font-weight: 700;
-  font-size: 1.8rem;
+  font-weight: var(--weight-bold);
+  font-size: var(--text-2xl);
   color: var(--primary-color);
-  font-family: var(--font-mono);
-  letter-spacing: 2px;
+  font-family: var(--font-display);
+  letter-spacing: var(--tracking-wide);
 }
 
 .app__header-right {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: var(--space-4);
 }
 
 .app__user-status {
   display: flex;
   align-items: center;
-  font-size: 0.9rem;
+  font-size: var(--text-sm);
   font-family: var(--font-mono);
 }
 
 .app__status-dot {
   width: 10px;
   height: 10px;
-  border-radius: 0;
-  margin-right: 8px;
+  border-radius: 50%;
+  margin-right: var(--space-2);
 }
 
 .app__status-dot--online {
@@ -73,8 +78,8 @@ body {
 
 .app__content {
   flex: 1;
-  padding: 2rem;
-  max-width: 1200px;
+  padding: var(--page-gutter);
+  max-width: var(--content-max-width);
   width: 100%;
   margin: 75px auto 0;
 }
@@ -100,15 +105,25 @@ body {
 
 @media (max-width: 1100px) {
   .app__content {
-    padding: 1rem;
+    padding: var(--space-4);
   }
 
   .app__header {
-    padding: 1rem;
+    padding: var(--space-4);
   }
 
   .app__header::before,
   .app__header::after {
-    left: 1rem;
+    left: var(--space-4);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
   }
 }

--- a/src/assets/styles/dashboard.css
+++ b/src/assets/styles/dashboard.css
@@ -22,7 +22,7 @@
   font-weight: 600;
   cursor: pointer;
   transition: var(--transition);
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
   position: relative;
 }
 
@@ -95,7 +95,8 @@
   margin-bottom: 1rem;
   color: var(--primary-color);
   font-weight: 600;
-  font-family: var(--font-mono);
+  font-family: var(--font-display);
+  letter-spacing: var(--tracking-wide);
   border-bottom: 1px solid var(--accent-color);
   padding-bottom: 0.5rem;
   position: relative;
@@ -144,7 +145,8 @@
   margin-bottom: 1rem;
   color: var(--primary-color);
   font-weight: 600;
-  font-family: var(--font-mono);
+  font-family: var(--font-display);
+  letter-spacing: var(--tracking-wide);
   border-bottom: 1px solid var(--accent-color);
   padding-bottom: 0.5rem;
   position: relative;
@@ -195,7 +197,8 @@
   margin-bottom: 1rem;
   color: var(--primary-color);
   font-weight: 600;
-  font-family: var(--font-mono);
+  font-family: var(--font-display);
+  letter-spacing: var(--tracking-wide);
   border-bottom: 1px solid var(--accent-color);
   padding-bottom: 0.5rem;
   position: relative;

--- a/src/assets/styles/data-card.css
+++ b/src/assets/styles/data-card.css
@@ -1,13 +1,13 @@
 .data-card {
   background: var(--card-color);
-  border-radius: var(--border-radius);
-  box-shadow: var(--shadow);
-  padding: 16px;
-  margin-bottom: 16px;
-  transition: transform 0.2s, box-shadow 0.2s;
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  padding: var(--card-padding);
+  margin-bottom: var(--space-4);
+  transition: var(--transition);
   border: var(--border-style);
   position: relative;
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
   overflow: hidden;
 }
 
@@ -43,7 +43,7 @@
 
 .data-card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 4px 8px var(--card-shadow);
+  box-shadow: var(--shadow-md);
   border-color: var(--primary-color);
 }
 
@@ -198,7 +198,7 @@
   cursor: pointer;
   font-weight: bold;
   transition: background-color 0.3s;
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
 }
 
 .data-card__delete-confirm-button {
@@ -210,7 +210,7 @@
   cursor: pointer;
   font-weight: bold;
   transition: background-color 0.3s;
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
 }
 
 .data-card__delete-cancel:hover {

--- a/src/assets/styles/data-display.css
+++ b/src/assets/styles/data-display.css
@@ -2,7 +2,7 @@
   min-height: 300px;
   width: 100%;
   position: relative;
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
   overflow-x: hidden;
 }
 
@@ -22,7 +22,7 @@
 
 .data-display__spinner {
   border: 4px solid var(--spinner-bg);
-  border-radius: 0;
+  border-radius: var(--radius-sm);
   border-top: 4px solid var(--primary-color);
   width: 30px;
   height: 30px;
@@ -41,7 +41,7 @@
   justify-content: center;
   height: 300px;
   color: var(--text-light);
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
   text-align: center;
 }
 
@@ -90,13 +90,13 @@
 .data-display__suggestions-button,
 .data-display__create-list-button {
   border: 1px solid var(--primary-color);
-  border-radius: 0;
+  border-radius: var(--radius-sm);
   font-weight: 500;
   cursor: pointer;
   transition: background-color 0.2s, transform 0.1s;
   font-size: 0.9rem;
   text-align: center;
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
   background-color: var(--primary-transparent-15);
   color: var(--text-color);
   padding: 0.5rem 0.75rem;
@@ -149,13 +149,13 @@
 
 .data-display__accept-all-result {
   background-color: #e6f7e6;
-  border-radius: 0;
+  border-radius: var(--radius-sm);
   color: #2e7d32;
   padding: 0.75rem 1rem;
   margin-bottom: 0;
   font-size: 0.9rem;
   border-left: 3px solid #2e7d32;
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
 }
 
 .data-display__accept-all-result--error {
@@ -166,11 +166,11 @@
 
 .data-display__refresh-text,
 .data-display__create-list-text {
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
 }
 
 .data-display__empty {
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
   white-space: pre;
   line-height: 1.2;
   color: var(--primary-color);
@@ -187,7 +187,7 @@
   justify-content: center;
   height: 300px;
   color: var(--text-light);
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
   text-align: center;
   width: 100%;
   overflow-x: hidden;
@@ -207,7 +207,7 @@
 .data-display__hint {
   font-size: 0.85rem;
   margin-top: 0.5rem;
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
   color: var(--text-light);
 }
 
@@ -218,7 +218,7 @@
   margin-bottom: 1.5rem;
   max-height: 200px;
   overflow-y: auto;
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
 }
 
 .data-display__detailed-result {
@@ -302,7 +302,7 @@
   right: 0.75rem;
   background-color: transparent;
   border: none;
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
   color: var(--secondary-color);
   cursor: pointer;
   font-size: 1rem;
@@ -322,7 +322,7 @@
   padding: 8px 12px;
   display: flex;
   align-items: center;
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
   font-size: 0.9rem;
   cursor: pointer;
   transition: background-color 0.2s, transform 0.1s;
@@ -387,7 +387,7 @@
   padding: 4px 8px;
   cursor: pointer;
   color: var(--text-color);
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
   transition: all 0.2s;
 }
 
@@ -405,7 +405,7 @@
   border: 1px solid var(--border-color);
   border-radius: 8px;
   background-color: var(--card-bg);
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
 }
 
 .data-display__delete-content {
@@ -432,7 +432,7 @@
   border: none;
   border-radius: 4px;
   cursor: pointer;
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
   font-weight: bold;
   transition: background-color 0.3s;
 }
@@ -444,7 +444,7 @@
   border: none;
   border-radius: 4px;
   cursor: pointer;
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
   font-weight: bold;
   transition: background-color 0.3s;
 }

--- a/src/assets/styles/list-chips.css
+++ b/src/assets/styles/list-chips.css
@@ -23,12 +23,12 @@
   background-color: var(--primary-transparent-10);
   color: var(--primary-color);
   border: 1px solid var(--primary-color);
-  border-radius: 0;
+  border-radius: var(--radius-sm);
   padding: 0;
   font-size: 0.85rem;
   cursor: pointer;
   transition: background-color 0.2s, transform 0.1s;
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
   overflow: hidden;
 }
 
@@ -81,12 +81,12 @@
   border-left: 4px solid var(--text-light);
   padding: 10px 12px;
   margin: 8px 0;
-  border-radius: 0;
+  border-radius: var(--radius-sm);
   color: var(--text-light);
   font-size: 0.9rem;
   display: flex;
   align-items: center;
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
 }
 
 .list-chips__message .list-chips__icon {

--- a/src/assets/styles/login-form.css
+++ b/src/assets/styles/login-form.css
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
   max-width: 600px;
   margin: 0 auto;
 }
@@ -27,7 +27,7 @@
   color: var(--primary-color);
   font-size: 0.9rem;
   padding-left: 15px;
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
 }
 
 .login-form__input-container {
@@ -42,7 +42,7 @@
   transition: var(--transition);
   background-color: var(--card-bg-transparent-50);
   color: var(--text-color);
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
   position: relative;
   width: 100%;
 }
@@ -78,7 +78,7 @@
 }
 
 .login-form__hint-box {
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
   white-space: pre;
   line-height: 1.2;
   color: var(--primary-color);
@@ -123,7 +123,7 @@
   cursor: pointer;
   transition: var(--transition);
   margin-top: 0.5rem;
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
   position: relative;
 }
 
@@ -150,7 +150,7 @@
   font-size: 0.8rem;
   color: var(--error-color);
   margin-top: 0.25rem;
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
   border-left: 2px solid var(--error-color);
   padding-left: 8px;
   display: flex;
@@ -175,7 +175,7 @@
   margin: 0;
   font-size: 0.85rem;
   color: var(--text-light);
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
   display: flex;
   align-items: center;
 }

--- a/src/assets/styles/pagination.css
+++ b/src/assets/styles/pagination.css
@@ -5,7 +5,7 @@
   margin-top: 1.5rem;
   padding: 1rem 0;
   border-top: 1px solid var(--primary-transparent-20);
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
 }
 
 .pagination--top {
@@ -31,9 +31,9 @@
   background-color: var(--primary-transparent-15);
   color: var(--text-color);
   border: 1px solid var(--primary-color);
-  border-radius: 0;
+  border-radius: var(--radius-sm);
   padding: 0.35rem 0.75rem;
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
   cursor: pointer;
   transition: background-color 0.2s, transform 0.1s;
   min-width: 2.5rem;

--- a/src/assets/styles/theme-toggle.css
+++ b/src/assets/styles/theme-toggle.css
@@ -1,20 +1,27 @@
 .theme-toggle {
-  background-color: var(--accent-transparent-50);
-  border: var(--border-style);
-  color: var(--text-color);
+  background-color: transparent;
+  border: 1px solid var(--border-strong);
+  color: var(--text-light);
   cursor: pointer;
-  padding: 0.5rem;
+  padding: var(--space-2);
   display: flex;
   align-items: center;
   justify-content: center;
   transition: var(--transition);
-  border-radius: var(--border-radius);
-  font-family: var(--font-mono);
-  font-size: 0.75rem;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
 }
 
 .theme-toggle:hover {
-  background-color: var(--accent-transparent-10);
+  background-color: var(--hover-bg);
+  border-color: var(--primary-color);
+  color: var(--primary-color);
+}
+
+.theme-toggle:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
 }
 
 .theme-toggle__icon {

--- a/yarn.lock
+++ b/yarn.lock
@@ -480,6 +480,13 @@
   resolved "https://registry.yarnpkg.com/@bomb.sh/tab/-/tab-0.0.19.tgz#c22f3b75c8a391a38cd956b7391b45551587d76a"
   integrity sha512-dTRfo9Q9B+lbLG3JCu8a/AGQSfD2XXcFcnakQzVjSOX+VvR/s9zpsH8TlqV3iHqazniRn1Ypwd1hcRlXcu/4BA==
 
+"@capsizecss/unpack@^4.0.0":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@capsizecss/unpack/-/unpack-4.0.1.tgz#5fc5f3a371a93a69d764e81a09badf0143381739"
+  integrity sha512-CuNiSqg7+e1cO/GjffyMOm5Tt2jUF9CWHHnvQ/UkqvtkGfHdgwEC0wpmq7fkN3gxwpRnrAN0WzO3vREKmNolMQ==
+  dependencies:
+    fontkitten "^1.0.3"
+
 "@clack/core@0.4.2":
   version "0.4.2"
   resolved "https://registry.npmjs.org/@clack/core/-/core-0.4.2.tgz"
@@ -1153,7 +1160,7 @@
   resolved "https://registry.npmjs.org/@nuxt/devalue/-/devalue-2.0.2.tgz"
   integrity sha512-GBzP8zOc7CGWyFQS6dv1lQz8VVpz5C2yRszbXufwG/9zhStTIH50EtD87NmWbTMwXDvZLNg8GIpb1UFdH93JCA==
 
-"@nuxt/devtools-kit@3.4.2":
+"@nuxt/devtools-kit@3.4.2", "@nuxt/devtools-kit@^3.2.1":
   version "3.4.2"
   resolved "https://registry.yarnpkg.com/@nuxt/devtools-kit/-/devtools-kit-3.4.2.tgz#951e50070ded4e71b5f2fa1ce812c7d7528f1778"
   integrity sha512-TPPbmH9xrExagYxfCe6JgtbHmgchfgDdA656Yws18rn8I/oCvB+gcw3kTWBBp2sC9ipZPXsgbsW/yZnVnGNBiA==
@@ -1275,7 +1282,28 @@
     pathe "^2.0.3"
     unimport "^4.1.2"
 
-"@nuxt/kit@4.5.2", "@nuxt/kit@^4.2.0", "@nuxt/kit@^4.5.1", "@nuxt/kit@^4.5.2":
+"@nuxt/fonts@^0.14.0":
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/@nuxt/fonts/-/fonts-0.14.0.tgz#8f98c39b5073c6811be7e24638e6ce5665118a66"
+  integrity sha512-4uXQl9fa5F4ibdgU8zomoOcyMdnwgdem+Pi8JEqeDYI5yPR32Kam6HnuRr47dTb97CstaepAvXPWQUUHMtjsFQ==
+  dependencies:
+    "@nuxt/devtools-kit" "^3.2.1"
+    "@nuxt/kit" "^4.2.2"
+    consola "^3.4.2"
+    defu "^6.1.4"
+    fontless "^0.2.1"
+    h3 "^1.15.5"
+    magic-regexp "^0.10.0"
+    ofetch "^1.5.1"
+    pathe "^2.0.3"
+    sirv "^3.0.2"
+    tinyglobby "^0.2.15"
+    ufo "^1.6.3"
+    unifont "^0.7.4"
+    unplugin "^3.0.0"
+    unstorage "^1.17.4"
+
+"@nuxt/kit@4.5.2", "@nuxt/kit@^4.2.0", "@nuxt/kit@^4.2.2", "@nuxt/kit@^4.5.1", "@nuxt/kit@^4.5.2":
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/@nuxt/kit/-/kit-4.5.2.tgz#fa338b169d14d9e66f973ded551d2376edb72398"
   integrity sha512-l66LU9DcJYjmNwqwAj2I5UGRrUbnG2DOKGChnN70zIGtn0eq/z87gi/FRgha6eMb9/FmB1PFHgtx6PWVml1C2Q==
@@ -3242,7 +3270,7 @@ css-select@^6.0.0:
     domutils "^3.2.2"
     nth-check "^2.1.1"
 
-css-tree@^3.0.1:
+css-tree@^3.0.1, css-tree@^3.1.0:
   version "3.2.1"
   resolved "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz"
   integrity sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==
@@ -3726,7 +3754,7 @@ es-to-primitive@^1.3.0:
     is-date-object "^1.1.0"
     is-symbol "^1.1.1"
 
-esbuild@>=0.28.1, esbuild@^0.25.0, esbuild@^0.27.3, esbuild@^0.28.0:
+esbuild@>=0.28.1, esbuild@^0.25.0, esbuild@^0.27.0, esbuild@^0.27.3, esbuild@^0.28.0:
   version "0.28.2"
   resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.28.2.tgz#0f43bd1bad955b72d24e2261e3abe5957ccf0816"
   integrity sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==
@@ -4231,6 +4259,45 @@ fnv1a-64@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/fnv1a-64/-/fnv1a-64-0.1.2.tgz#1cca3d160c92c0d8e5b3df3a9d8e2f71cbb7b2e8"
   integrity sha512-mJbcILTPybAR1jdOwt/lVv8N2cffeJFFP+gVbSAwLEx1ujXH27RpPd8Rokec/KX9c76UYIB6Co+H4lQzxPnJfA==
+
+fontaine@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/fontaine/-/fontaine-0.8.0.tgz#73bfda43e5169465c3af2eec51b6eaa2d0543ba2"
+  integrity sha512-eek1GbzOdWIj9FyQH/emqW1aEdfC3lYRCHepzwlFCm5T77fBSRSyNRKE6/antF1/B1M+SfJXVRQTY9GAr7lnDg==
+  dependencies:
+    "@capsizecss/unpack" "^4.0.0"
+    css-tree "^3.1.0"
+    magic-regexp "^0.10.0"
+    magic-string "^0.30.21"
+    pathe "^2.0.3"
+    ufo "^1.6.1"
+    unplugin "^2.3.10"
+
+fontkitten@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/fontkitten/-/fontkitten-1.0.3.tgz#bbafdeddbb1e054967f0846fdc757accab88bb68"
+  integrity sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==
+  dependencies:
+    tiny-inflate "^1.0.3"
+
+fontless@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/fontless/-/fontless-0.2.1.tgz#c1cf376a902ce01e600d3fbcd87126feb24752e5"
+  integrity sha512-mUWZ8w91/mw2KEcZ6gHNoNNmsAq9Wiw2IypIux5lM03nhXm+WSloXGUNuRETNTLqZexMgpt7Aj/v63qqrsWraQ==
+  dependencies:
+    consola "^3.4.2"
+    css-tree "^3.1.0"
+    defu "^6.1.4"
+    esbuild "^0.27.0"
+    fontaine "0.8.0"
+    jiti "^2.6.1"
+    lightningcss "^1.30.2"
+    magic-string "^0.30.21"
+    ohash "^2.0.11"
+    pathe "^2.0.3"
+    ufo "^1.6.1"
+    unifont "^0.7.4"
+    unstorage "^1.17.1"
 
 for-each@^0.3.3, for-each@^0.3.5:
   version "0.3.5"
@@ -5230,7 +5297,7 @@ lightningcss-win32-x64-msvc@1.33.0:
   resolved "https://registry.yarnpkg.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz#e343ae152eed3609dc6e11949d1a3bf39a1c946f"
   integrity sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==
 
-lightningcss@^1.33.0:
+lightningcss@^1.30.2, lightningcss@^1.33.0:
   version "1.33.0"
   resolved "https://registry.yarnpkg.com/lightningcss/-/lightningcss-1.33.0.tgz#c08867d71a79385c6e190214fd72fef3e5f95f0b"
   integrity sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==
@@ -5420,6 +5487,19 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+magic-regexp@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/magic-regexp/-/magic-regexp-0.10.0.tgz#78b4421a50d2b7a67129bf2c424a333927c3a0e5"
+  integrity sha512-Uly1Bu4lO1hwHUW0CQeSWuRtzCMNO00CmXtS8N6fyvB3B979GOEEeAkiTUDsmbYLAbvpUS/Kt5c4ibosAzVyVg==
+  dependencies:
+    estree-walker "^3.0.3"
+    magic-string "^0.30.12"
+    mlly "^1.7.2"
+    regexp-tree "^0.1.27"
+    type-level-regexp "~0.1.17"
+    ufo "^1.5.4"
+    unplugin "^2.0.0"
+
 magic-string-ast@^1.0.2:
   version "1.0.3"
   resolved "https://registry.npmjs.org/magic-string-ast/-/magic-string-ast-1.0.3.tgz"
@@ -5427,7 +5507,7 @@ magic-string-ast@^1.0.2:
   dependencies:
     magic-string "^0.30.19"
 
-magic-string@^0.30.17, magic-string@^0.30.19, magic-string@^0.30.21, magic-string@^0.30.3:
+magic-string@^0.30.12, magic-string@^0.30.17, magic-string@^0.30.19, magic-string@^0.30.21, magic-string@^0.30.3:
   version "0.30.21"
   resolved "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz"
   integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
@@ -5565,7 +5645,7 @@ mitt@^3.0.1:
   resolved "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz"
   integrity sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==
 
-mlly@^1.7.4, mlly@^1.8.0, mlly@^1.8.2:
+mlly@^1.7.2, mlly@^1.7.4, mlly@^1.8.0, mlly@^1.8.2:
   version "1.8.2"
   resolved "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz"
   integrity sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==
@@ -7425,6 +7505,11 @@ text-extensions@^2.0.0:
   resolved "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
   integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
 
+tiny-inflate@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-inflate/-/tiny-inflate-1.0.3.tgz#122715494913a1805166aaf7c93467933eea26c4"
+  integrity sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==
+
 tiny-invariant@^1.3.3:
   version "1.3.3"
   resolved "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz"
@@ -7513,6 +7598,11 @@ type-fest@^5.0.0:
   integrity sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==
   dependencies:
     tagged-tag "^1.0.0"
+
+type-level-regexp@~0.1.17:
+  version "0.1.17"
+  resolved "https://registry.yarnpkg.com/type-level-regexp/-/type-level-regexp-0.1.17.tgz#ec1bf7dd65b85201f9863031d6f023bdefc2410f"
+  integrity sha512-wTk4DH3cxwk196uGLK/E9pE45aLfeKJacKmcEgEOA/q5dnPGNxXt0cfYdFxb57L+sEpf1oJH4Dnx/pnRcku9jg==
 
 typed-array-buffer@^1.0.3:
   version "1.0.3"
@@ -7616,7 +7706,7 @@ undici-types@~8.3.0:
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz"
   integrity sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==
 
-undici@^8.10.0:
+undici@^8.0.0, undici@^8.10.0:
   version "8.10.0"
   resolved "https://registry.yarnpkg.com/undici/-/undici-8.10.0.tgz#67ed7c4087f0f40fba7bef3a46f2be80572f2473"
   integrity sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==
@@ -7662,6 +7752,15 @@ unicorn-magic@^0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz"
   integrity sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==
+
+unifont@^0.7.4:
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/unifont/-/unifont-0.7.5.tgz#28fb7973693263da1fd6e0bc2a24585b69a6011c"
+  integrity sha512-ULe/Cs+ZIsq+dcFofNkhqielCrUJnb5mr+Yc4EBM2VlL+6OZR6+cjtI2mT1bJvRBrVncqHAbLURxmPLcCXzWMg==
+  dependencies:
+    css-tree "^3.1.0"
+    ohash "^2.0.11"
+    undici "^8.0.0"
 
 unimport@^4.1.2:
   version "4.2.0"
@@ -7719,7 +7818,7 @@ unplugin-utils@^0.3.0, unplugin-utils@^0.3.1, unplugin-utils@^0.3.2:
     pathe "^2.0.3"
     picomatch "^4.0.4"
 
-unplugin@^2.2.0, unplugin@^2.2.2, unplugin@^2.3.11:
+unplugin@^2.0.0, unplugin@^2.2.0, unplugin@^2.2.2, unplugin@^2.3.10, unplugin@^2.3.11:
   version "2.3.11"
   resolved "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz"
   integrity sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==
@@ -7776,7 +7875,7 @@ unrs-resolver@^1.9.2:
     "@unrs/resolver-binding-win32-ia32-msvc" "1.12.2"
     "@unrs/resolver-binding-win32-x64-msvc" "1.12.2"
 
-unstorage@^1.15.0, unstorage@^1.17.5:
+unstorage@^1.15.0, unstorage@^1.17.1, unstorage@^1.17.4, unstorage@^1.17.5:
   version "1.17.5"
   resolved "https://registry.npmjs.org/unstorage/-/unstorage-1.17.5.tgz"
   integrity sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==


### PR DESCRIPTION
## What

Applies the **Poolside** (プールサイド) city pop theme to Bluelist, and lands the design record
behind it.

**Behaviour is unchanged.** Nothing under `src/lib`, `src/stores`, `src/types`, `server/` or
`middleware/` is touched — this is presentation only.

## How to review

Open **`docs/themes/theme-b-poolside.html`** in a browser. It renders the theme on mock
Bluelist surfaces with working dark/light and decoration toggles, so you can compare intent
against the running app. `docs/themes/index.html` shows all three proposed families side by
side if you want to see what was rejected.

Full specs: [dark](docs/themes/theme-b-poolside-dark.md) ·
[light](docs/themes/theme-b-poolside-light.md)

## Expect visual diffs in places this PR didn't seem to touch

Fourteen tokens were referenced in component CSS but **never defined**, so those rules
silently did nothing. They now resolve. Card modals gain a background, destructive buttons
gain a hover state, and several tinted surfaces appear for the first time. This is the fix,
not a regression.

Separately, the `*-transparent-*` tokens were derived from a different hue than their base —
dark mode's primary was blue `#a0d6ff` while its alpha variants were orange. Every alpha
variant is now derived from its own base, so hover and focus states stop tinting toward
colours that appear nowhere else in the palette.

## Two decisions worth a second opinion

**Light mode does not mirror dark.** Dark's pool aqua `#45D0E0` sits at roughly 1.7:1 on a
light page — unusable as text. Light mode uses a deep aqua `#00707F` and moves the pale sky
tone to the *background* instead. Please don't "fix" these to match.

**The light card is pure white on a tinted page** (`#FFFFFF` on `#EAF6FA`). The old light
theme was `#ffffff` on `#f7f7f8`, near-identical, so cards were nearly invisible. They now
read as objects sitting on the page. Intended.

## Accessibility

Every colour pair was measured with the WCAG 2.1 relative-luminance formula against both the
page and card backgrounds; the lower figure is what's recorded in the specs. Body and brand
colours clear 4.5:1, disabled text and control borders clear 3:1.

A new `--border-strong` token was required — no existing border reached the 3:1 that
SC 1.4.11 demands for form-control borders. `:focus` was swapped for `:focus-visible`, and a
`prefers-reduced-motion` guard added.

## Fonts

Outfit (display), Inter (body), IBM Plex Mono (data), self-hosted and subset via `@nuxt/fonts`.
No runtime request to a third-party CDN — verified there are no `fonts.googleapis.com` or
`fonts.gstatic.com` references in the build output.

Monospace is demoted from the global `body` font to **data only**: the user handle, ASCII art
and the terminal cursor. Mono-everywhere read as a terminal rather than 1980s Tokyo.

## Decoration is off by default

The sky gradient and button sheen sit behind `[data-decor='on']` on `<html>`. Nothing turns
them on yet — set the attribute manually to preview.

## Verification

- `yarn lint` passes; `yarn build` succeeds; `vue-tsc` reports 0 errors
- Both modes checked in a browser
- Every `var()` in the stylesheets resolves to a defined token
- Themes A and C are kept as design record and are not implemented

## Notes

- `@nuxt/fonts` install needed Node ≥22.19; the repo's Nuxt 4.5.2 already required it, so this
  isn't a new constraint, but it's worth knowing if your local Node is older.
- Kana micro-labels were proposed during design and dropped before implementation. Themes A
  and C still describe them, as originally written.
  
## Closes
#30 
